### PR TITLE
BugFix: Activity Medal Emojis are incorrect when activity types are mixed

### DIFF
--- a/slack-strava/models/team_leaderboard.rb
+++ b/slack-strava/models/team_leaderboard.rb
@@ -92,6 +92,7 @@ class TeamLeaderboard
           },
           {
             '$setWindowFields': {
+              partitionBy: '$_id.type',
               sortBy: { metric_field => -1 },
               output: {
                 rank: { '$denseRank': {} }

--- a/spec/models/team_leaderboard_spec.rb
+++ b/spec/models/team_leaderboard_spec.rb
@@ -124,7 +124,7 @@ describe TeamLeaderboard do
             {
               '_id' => { 'user_id' => user1.id, 'type' => 'Swim' },
               'distance' => user1_swim_activity_1.distance + user1_swim_activity_2.distance,
-              'rank' => 3
+              'rank' => 1
             }
           ]
         )
@@ -135,7 +135,7 @@ describe TeamLeaderboard do
           [
             "1: #{user1.user_name} 🏃 #{format('%.2f', (user1_activity_1.distance + user1_activity_2.distance + user1_activity_3.distance) * 0.00062137)}mi",
             "2: #{user2.user_name} 🏃 #{format('%.2f', user2_activity_1.distance * 0.00062137)}mi",
-            "3: #{user1.user_name} 🏊 #{format('%.1f', (user1_swim_activity_1.distance + user1_swim_activity_2.distance) * 1.09361)}yd"
+            "1: #{user1.user_name} 🏊 #{format('%.1f', (user1_swim_activity_1.distance + user1_swim_activity_2.distance) * 1.09361)}yd"
           ].join("\n")
         )
       end
@@ -148,20 +148,26 @@ describe TeamLeaderboard do
         expect(leaderboard.aggregate!.to_a).to eq(
           [
             { '_id' => { 'user_id' => user1.id, 'type' => 'Run' }, 'count' => 3, 'rank' => 1 },
-            { '_id' => { 'user_id' => user1.id, 'type' => 'Swim' }, 'count' => 2, 'rank' => 2 },
-            { '_id' => { 'user_id' => user2.id, 'type' => 'Run' }, 'count' => 1, 'rank' => 3 }
-          ]
+            { '_id' => { 'user_id' => user2.id, 'type' => 'Run' }, 'count' => 1, 'rank' => 2 },
+            { '_id' => { 'user_id' => user1.id, 'type' => 'Swim' }, 'count' => 2, 'rank' => 1 }
+          ].sort_by { |h| [h['rank'], h['_id']['type']] }
         )
       end
 
       it 'to_s' do
-        expect(leaderboard.to_s).to eq(
+        expected_strings = [
           [
             "1: #{user1.user_name} 🏃 3",
-            "2: #{user1.user_name} 🏊 2",
-            "3: #{user2.user_name} 🏃 1"
+            "2: #{user2.user_name} 🏃 1",
+            "1: #{user1.user_name} 🏊 2"
+          ].join("\n"),
+          [
+            "1: #{user1.user_name} 🏊 2",
+            "1: #{user1.user_name} 🏃 3",
+            "2: #{user2.user_name} 🏃 1"
           ].join("\n")
-        )
+        ]
+        expect(expected_strings).to include(leaderboard.to_s)
       end
     end
 
@@ -231,7 +237,7 @@ describe TeamLeaderboard do
             {
               '_id' => { 'user_id' => user1.id, 'type' => 'Swim' },
               'distance' => user1_swim_activity_2.distance,
-              'rank' => 2
+              'rank' => 1
             }
           ]
         )
@@ -257,7 +263,7 @@ describe TeamLeaderboard do
             {
               '_id' => { 'user_id' => user1.id, 'type' => 'Swim' },
               'distance' => user1_swim_activity_1.distance,
-              'rank' => 3
+              'rank' => 1
             }
           ]
         )


### PR DESCRIPTION
If the TeamLeaderBoard has a mix of activityTypes the `position` field in `find` is incorrect. This results in the wrong medal emoji being shown on individual activities. 

I am not sure if this is intentional behavior or not, since the tests seem to indicate that you want it to work this way, however it seems a bit counter-intuitive since you pass activity_type in the medal method.

Here is a PR that should fix it, if you want to change the behavior.