### PR TITLE
BugFix - Medals should be assigned based on Rank & Activity Type

### DIFF
--- a/slack-strava/models/team_leaderboard.rb
+++ b/slack-strava/models/team_leaderboard.rb
@@ -104,10 +104,21 @@ class TeamLeaderboard
   end
 
   def find(user_id, activity_type)
-    position = aggregate!.find_index do |row|
-      row[:_id][:user_id] == user_id && row[:_id][:type] == activity_type
+    # Get the full leaderboard ranked by the metric
+    full_leaderboard = aggregate!
+
+    # Filter by the specific activity type
+    filtered_leaderboard = full_leaderboard.select do |row|
+      row[:_id][:type] == activity_type
     end
-    position && position >= 0 ? position + 1 : nil
+
+    # Find the position (0-based index) of the user in the filtered list
+    position_in_type = filtered_leaderboard.find_index do |row|
+      row[:_id][:user_id] == user_id
+    end
+
+    # Return the 1-based rank, or nil if not found
+    position_in_type ? position_in_type + 1 : nil
   end
 
   def to_s

--- a/slack-strava/models/user.rb
+++ b/slack-strava/models/user.rb
@@ -323,7 +323,11 @@ class User
   end
 
   def medal_s(activity_type)
-    case team.leaderboard(metric: 'Distance').find(_id, activity_type)
+    # Find the user's rank within the specified activity type on the Distance leaderboard
+    rank_in_type = team.leaderboard(metric: 'Distance').find(_id, activity_type)
+
+    # Determine the medal based on the rank
+    case rank_in_type
     when 1
       '🥇'
     when 2

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -749,20 +749,35 @@ describe User do
       end
 
       context 'with an activity of a different type' do
-        let!(:activity) { Fabricate(:user_activity, user: user) }
+        let!(:activity) { Fabricate(:user_activity, user: user, distance: 1000) }
+        let!(:swim_activity) { Fabricate(:swim_activity, user: user, distance: 500) }
 
-        context 'ranked first' do
-          before do
-            Fabricate(:swim_activity, user: user)
-          end
+        it 'returns gold for Run as it is the only Run' do
+          expect(user.medal_s('Run')).to eq '🥇'
+        end
 
-          it 'returns a gold medal' do
-            expect(user.medal_s('Swim')).to eq '🥈'
-          end
+        it 'returns gold for Swim as it is the only Swim' do
+          expect(user.medal_s('Swim')).to eq '🥇'
+        end
+      end
 
-          it 'returns a silver medal' do
-            expect(user.medal_s('Run')).to eq '🥇'
-          end
+      context 'when rank differs between overall and activity type' do
+        let!(:user1_run) { Fabricate(:user_activity, user: Fabricate(:user, team: user.team), distance: 3000, type: 'Run') }
+        let!(:user2_swim) { Fabricate(:user_activity, user: Fabricate(:user, team: user.team), distance: 2000, type: 'Swim') }
+        let!(:user3_run) { Fabricate(:user_activity, user: user, distance: 1000, type: 'Run') }
+
+        it 'returns silver for the second Run activity, ignoring Swim' do
+          # Overall rank: user1_run (1st), user2_swim (2nd), user3_run (3rd)
+          # Run rank: user1_run (1st), user3_run (2nd)
+          expect(user.medal_s('Run')).to eq '🥈'
+        end
+
+        it 'returns nil for Swim as the user has no Swim activity' do
+          expect(user.medal_s('Swim')).to be_nil
+        end
+
+        it 'returns nil for Ride as there are no Ride activities' do
+          expect(user.medal_s('Ride')).to be_nil
         end
       end
     end


### PR DESCRIPTION
Second attempt at fixing this, this time leaving the aggregation alone, so the existing leaderboard logic remains as-is.

In this case, I'm introducing application level filtering to ensure only activities of the same type are considered when picking the medal emoji.

Apologies, I don't have a ruby env setup on this laptop and vibe coded this with cursor.