### PR TITLE
Return 1x1 transparent pixel instead of 404/403 for expired/missing maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Changelog
 
+* 2026/04/11: Return a 1x1 transparent pixel instead of a 404/403 error when activity maps are not found or have expired - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/11: Upgraded Ruby to 4.0.2, puma to 8.0.0, addressable to 2.9.0, stripe to 13.5.1, stripe-ruby-mock to 5.0.0 - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/03/20: Added per-channel settings for maps, threads, fields, units, and userlimit - admin `set` in a channel overrides team defaults - [@dblock](https://github.com/dblock).
 * 2026/03/20: Added `set activities` to limit activity types posted in a channel - [@dblock](https://github.com/dblock).

--- a/slack-strava/api/endpoints/maps_endpoint.rb
+++ b/slack-strava/api/endpoints/maps_endpoint.rb
@@ -3,6 +3,11 @@ module Api
     class MapsEndpoint < Grape::API
       content_type :png, 'image/png'
 
+      # 1x1 transparent PNG pixel returned when a map is not available.
+      PIXEL_PNG = Base64.decode64(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQI12NgAAIABQAABjE+ibYAAAAASUVORK5CYII='
+      ).freeze
+
       namespace :maps do
         desc 'Proxy display a map.'
         params do
@@ -12,20 +17,24 @@ module Api
           user_agent = headers['User-Agent'] || 'Unknown User-Agent'
           activity = UserActivity.where('map._id' => BSON::ObjectId(params[:id])).first
           if activity.nil?
-            Api::Middleware.logger.debug "Map #{params[:id]} for #{user_agent}, not found (404)."
-            error!('Not Found', 404)
+            Api::Middleware.logger.info "Map #{params[:id]} for #{user_agent}, not found, returning pixel."
+            content_type 'image/png'
+            body MapsEndpoint::PIXEL_PNG
           elsif activity.hidden?
-            Api::Middleware.logger.debug "Map png for #{activity.user}, #{activity} for #{user_agent}, hidden (403)."
-            error!('Access Denied', 403)
+            Api::Middleware.logger.info "Map png for #{activity.user}, #{activity} for #{user_agent}, hidden, returning pixel."
+            content_type 'image/png'
+            body MapsEndpoint::PIXEL_PNG
           elsif !activity.map&.polyline?
-            Api::Middleware.logger.debug "Map png for #{activity.user}, #{activity} for #{user_agent}, no map (404)."
-            error!('Map Not Found', 404)
+            Api::Middleware.logger.info "Map png for #{activity.user}, #{activity} for #{user_agent}, no map, returning pixel."
+            content_type 'image/png'
+            body MapsEndpoint::PIXEL_PNG
           elsif activity.user.team.proxy_maps
             # will also re-fetch the map if needed
             activity.map.update_attributes!(png_retrieved_at: Time.now.utc)
             unless activity.map.png
-              Api::Middleware.logger.debug "Map png for #{activity.user}, #{activity} for #{user_agent}, no data (404)."
-              error!('Map Data Not Found', 404)
+              Api::Middleware.logger.info "Map png for #{activity.user}, #{activity} for #{user_agent}, no data, returning pixel."
+              content_type 'image/png'
+              next body MapsEndpoint::PIXEL_PNG
             end
             content_type 'image/png'
             png = activity.map.png.data

--- a/spec/api/endpoints/maps_endpoint_spec.rb
+++ b/spec/api/endpoints/maps_endpoint_spec.rb
@@ -5,10 +5,11 @@ describe Api::Endpoints::MapsEndpoint do
 
   context 'maps' do
     context 'without an activity' do
-      it '404s' do
+      it 'returns a pixel' do
         get '/api/maps/5abd07019b0b58f119c1bbaa.png'
-        expect(last_response.status).to eq 404
-        expect(JSON.parse(last_response.body)).to eq('error' => 'Not Found')
+        expect(last_response.status).to eq 200
+        expect(last_response.headers['Content-Type']).to eq 'image/png'
+        expect(last_response.body).to eq Api::Endpoints::MapsEndpoint::PIXEL_PNG
       end
     end
 
@@ -37,7 +38,9 @@ describe Api::Endpoints::MapsEndpoint do
         it 'returns no map data' do
           allow_any_instance_of(Map).to receive(:update_png!)
           get "/api/maps/#{activity.map.id}.png"
-          expect(last_response.status).to eq 404
+          expect(last_response.status).to eq 200
+          expect(last_response.headers['Content-Type']).to eq 'image/png'
+          expect(last_response.body).to eq Api::Endpoints::MapsEndpoint::PIXEL_PNG
         end
 
         it 'refetches map if needed', vcr: { cassette_name: 'strava/map', allow_playback_repeats: true } do
@@ -137,9 +140,11 @@ describe Api::Endpoints::MapsEndpoint do
       let(:user) { Fabricate(:user, private_activities: false) }
       let(:activity) { Fabricate(:user_activity, private: true, user: user) }
 
-      it 'does not return map' do
+      it 'returns a pixel' do
         get "/api/maps/#{activity.map.id}.png"
-        expect(last_response.status).to eq 403
+        expect(last_response.status).to eq 200
+        expect(last_response.headers['Content-Type']).to eq 'image/png'
+        expect(last_response.body).to eq Api::Endpoints::MapsEndpoint::PIXEL_PNG
       end
     end
 
@@ -151,9 +156,11 @@ describe Api::Endpoints::MapsEndpoint do
         activity.map.update_attributes!(summary_polyline: nil)
       end
 
-      it 'does not return map' do
+      it 'returns a pixel' do
         get "/api/maps/#{activity.map.id}.png"
-        expect(last_response.status).to eq 404
+        expect(last_response.status).to eq 200
+        expect(last_response.headers['Content-Type']).to eq 'image/png'
+        expect(last_response.body).to eq Api::Endpoints::MapsEndpoint::PIXEL_PNG
       end
     end
   end


### PR DESCRIPTION
Fixes #122.

When activities expire and get purged, map image URLs were returning 404/403 errors, making Slack messages look broken with broken image icons.

This change returns a 1x1 transparent PNG pixel (`PIXEL_PNG`) for all unavailable-map cases:
- Activity not found (expired/purged)  
- Activity hidden/private  
- Activity has no polyline  
- Activity has no map image data

The pixel is defined as a constant `MapsEndpoint::PIXEL_PNG` (base64-decoded transparent PNG) and reused in tests for assertions.