### PR TITLE
Add separate temperature units setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Changelog
 
+* 2026/04/11: Added `set temperature f|c|both|auto` to control temperature units independently from distance units - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/11: Return a 1x1 transparent pixel instead of a 404/403 error when activity maps are not found or have expired - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/11: Upgraded Ruby to 4.0.2, puma to 8.0.0, addressable to 2.9.0, stripe to 13.5.1, stripe-ruby-mock to 5.0.0 - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/03/20: Added per-channel settings for maps, threads, fields, units, and userlimit - admin `set` in a channel overrides team defaults - [@dblock](https://github.com/dblock).

--- a/slack-strava/commands/help.rb
+++ b/slack-strava/commands/help.rb
@@ -29,6 +29,7 @@ module SlackStrava
         set userlimit [n]|none                 - max per user per day (in channel overrides team default)
         set channellimit [n]|none              - max activities posted per channel per day (default is unlimited)
         set units imperial|metric|both         - use imperial vs. metric units (in channel overrides team default)
+        set temperature f|c|both               - temperature units, independent of distance units (in channel overrides team default)
         set fields all|none|...                - activity fields displayed (in channel overrides team default)
         set maps off|full|thumb                - map display style (in channel overrides team default)
         set leaderboard elapsed time|...       - change the default leaderboard

--- a/slack-strava/commands/set.rb
+++ b/slack-strava/commands/set.rb
@@ -72,6 +72,36 @@ module SlackStrava
                 logger.info "SET: #{team} - units set to #{team.units}"
               end
             end
+          when 'temperature'
+            case v
+            when 'celsius'
+              v = 'c'
+            when 'fahrenheit'
+              v = 'f'
+            end
+            if data.channel.start_with?('C')
+              channel_info = team.slack_client.conversations_info(channel: data.channel).channel
+              channel_name = channel_info['name']
+              changed = v && team.channel_temperature_for(data.channel) != v
+              if !user.team_admin? && changed
+                client.say(channel: data.channel, text: "Sorry, only <@#{team.activated_user_id}> or a Slack admin can change temperature. Activities in <##{data.channel}> display *#{team.channel_temperature_s(data.channel)}*.")
+                logger.info "SET: #{team} - not admin, temperature for #{data.channel} remain #{team.channel_temperature_for(data.channel)}"
+              else
+                team.set_channel!(data.channel, channel_name, temperature: v) if changed
+                client.say(channel: data.channel, text: "Activities in <##{data.channel}>#{' now' if changed} display *#{team.channel_temperature_s(data.channel)}*.")
+                logger.info "SET: #{team} - temperature for #{data.channel} set to #{team.channel_temperature_for(data.channel)}"
+              end
+            else
+              changed = v && team.temperature != v
+              if !user.team_admin? && changed
+                client.say(channel: data.channel, text: "Sorry, only <@#{team.activated_user_id}> or a Slack admin can change temperature. Activities for team #{team.name} display *#{team.temperature_s}*.")
+                logger.info "SET: #{team} - not admin, temperature remains set to #{team.temperature}"
+              else
+                team.update_attributes!(temperature: v) unless v.nil?
+                client.say(channel: data.channel, text: "Activities for team #{team.name}#{' now' if changed} display *#{team.temperature_s}*.")
+                logger.info "SET: #{team} - temperature set to #{team.temperature}"
+              end
+            end
           when 'fields'
             parsed_fields = ActivityFields.parse_s(v) if v
             if data.channel.start_with?('C')
@@ -269,6 +299,7 @@ module SlackStrava
           in_channel = data.channel.start_with?('C')
           messages = [
             in_channel ? "Activities in <##{data.channel}> display *#{team.channel_units_s(data.channel)}*." : "Activities for team #{team.name} display *#{team.units_s}*.",
+            in_channel ? "Activities in <##{data.channel}> display *#{team.channel_temperature_s(data.channel)}*." : "Activities for team #{team.name} display *#{team.temperature_s}*.",
             in_channel ? "Activities in <##{data.channel}> are *#{team.channel_threads_s(data.channel)}*." : "Activities are *#{team.threads_s}*.",
             "Activities are retained for *#{team.retention_s}*.",
             "Timezone is *#{team.timezone_s}*.",

--- a/slack-strava/models/activity_methods.rb
+++ b/slack-strava/models/activity_methods.rb
@@ -17,6 +17,10 @@ module ActivityMethods
     team.channel_units_for(current_channel_id)
   end
 
+  def effective_temperature
+    team.channel_temperature_for(current_channel_id)
+  end
+
   def effective_activity_fields
     team.channel_activity_fields_for(current_channel_id)
   end

--- a/slack-strava/models/channel.rb
+++ b/slack-strava/models/channel.rb
@@ -7,6 +7,7 @@ class Channel
   field :activity_types, type: Array, default: []
   field :maps, type: String
   field :units, type: String
+  field :temperature, type: String
   field :activity_fields, type: Array
   field :threads, type: String
   field :max_activities_per_user_per_day, type: Integer
@@ -27,10 +28,14 @@ class Channel
 
   def units_s
     {
-      'mi' => 'miles, feet, yards, and degrees Fahrenheit',
-      'km' => 'kilometers, meters, and degrees Celsius',
+      'mi' => 'miles, feet, and yards',
+      'km' => 'kilometers and meters',
       'both' => 'both units'
     }[units]
+  end
+
+  def temperature_s
+    { 'f' => 'degrees Fahrenheit', 'c' => 'degrees Celsius', 'both' => 'degrees Fahrenheit and Celsius' }[temperature]
   end
 
   def activity_fields_s

--- a/slack-strava/models/team.rb
+++ b/slack-strava/models/team.rb
@@ -4,6 +4,9 @@ class Team
   field :units, type: String, default: 'mi'
   validates_inclusion_of :units, in: %w[mi km both]
 
+  field :temperature, type: String, default: 'f'
+  validates_inclusion_of :temperature, in: %w[f c both]
+
   field :activity_fields, type: Array, default: ['Default']
   validates :activity_fields, array: { presence: true, inclusion: { in: ActivityFields.values } }
 
@@ -60,14 +63,18 @@ class Team
   def units_s
     case units
     when 'mi'
-      'miles, feet, yards, and degrees Fahrenheit'
+      'miles, feet, and yards'
     when 'km'
-      'kilometers, meters, and degrees Celsius'
+      'kilometers and meters'
     when 'both'
       'both units'
     else
       raise ArgumentError
     end
+  end
+
+  def temperature_s
+    { 'f' => 'degrees Fahrenheit', 'c' => 'degrees Celsius', 'both' => 'degrees Fahrenheit and Celsius' }[temperature] || raise(ArgumentError)
   end
 
   def maps_s
@@ -485,6 +492,18 @@ class Team
   def channel_units_s(channel_id)
     c = channels.find_by(channel_id: channel_id)
     c&.units_s || units_s
+  end
+
+  def channel_temperature_for(channel_id)
+    return temperature unless channel_id
+
+    c = channels.find_by(channel_id: channel_id)
+    c&.temperature || temperature
+  end
+
+  def channel_temperature_s(channel_id)
+    c = channels.find_by(channel_id: channel_id)
+    c&.temperature_s || temperature_s
   end
 
   def channel_activity_fields_for(channel_id)

--- a/slack-strava/models/user_activity.rb
+++ b/slack-strava/models/user_activity.rb
@@ -372,10 +372,10 @@ class UserActivity < Activity
 
     main = current_weather.weather&.first&.main
 
-    case team.units
-    when 'km' then
+    case effective_temperature
+    when 'c' then
       ["#{current_weather.temp_c.to_i}°C", main].compact.join(' ')
-    when 'mi' then
+    when 'f' then
       ["#{current_weather.temp_f.to_i}°F", main].compact.join(' ')
     when 'both' then
       [

--- a/spec/models/user_activity_spec.rb
+++ b/spec/models/user_activity_spec.rb
@@ -882,7 +882,7 @@ describe UserActivity do
   end
 
   context 'km' do
-    let(:team) { Fabricate(:team, units: 'km') }
+    let(:team) { Fabricate(:team, units: 'km', temperature: 'c') }
     let(:user) { Fabricate(:user, team: team) }
     let(:activity) { Fabricate(:user_activity, user: user) }
 
@@ -923,7 +923,7 @@ describe UserActivity do
   end
 
   context 'both' do
-    let(:team) { Fabricate(:team, units: 'both') }
+    let(:team) { Fabricate(:team, units: 'both', temperature: 'both') }
     let(:user) { Fabricate(:user, team: team) }
     let(:activity) { Fabricate(:user_activity, user: user) }
 

--- a/spec/slack-strava/commands/set_spec.rb
+++ b/spec/slack-strava/commands/set_spec.rb
@@ -26,7 +26,8 @@ describe SlackStrava::Commands::Set do
 
       it 'shows current settings in a DM' do
         expect(message: "#{SlackRubyBot.config.user} set").to respond_with_slack_message([
-          "Activities for team #{team.name} display *miles, feet, yards, and degrees Fahrenheit*.",
+          "Activities for team #{team.name} display *miles, feet, and yards*.",
+          "Activities for team #{team.name} display *degrees Fahrenheit*.",
           'Activities are *displayed individually*.',
           'Activities are retained for *1 month*.',
           "Timezone is *#{team.timezone_s}*.",
@@ -43,7 +44,8 @@ describe SlackStrava::Commands::Set do
 
       it 'shows current settings in a channel' do
         expect(message: "#{SlackRubyBot.config.user} set", channel: 'C1').to respond_with_slack_message([
-          'Activities in <#C1> display *miles, feet, yards, and degrees Fahrenheit*.',
+          'Activities in <#C1> display *miles, feet, and yards*.',
+          'Activities in <#C1> display *degrees Fahrenheit*.',
           'Activities in <#C1> are *displayed individually*.',
           'Activities are retained for *1 month*.',
           "Timezone is *#{team.timezone_s}*.",
@@ -217,21 +219,21 @@ describe SlackStrava::Commands::Set do
         context 'units' do
           it 'shows current value of units' do
             expect(message: "#{SlackRubyBot.config.user} set units").to respond_with_slack_message(
-              "Activities for team #{team.name} display *miles, feet, yards, and degrees Fahrenheit*."
+              "Activities for team #{team.name} display *miles, feet, and yards*."
             )
           end
 
           it 'shows current value of units set to km' do
             team.update_attributes!(units: 'km')
             expect(message: "#{SlackRubyBot.config.user} set units").to respond_with_slack_message(
-              "Activities for team #{team.name} display *kilometers, meters, and degrees Celsius*."
+              "Activities for team #{team.name} display *kilometers and meters*."
             )
           end
 
           it 'sets units to mi' do
             team.update_attributes!(units: 'km')
             expect(message: "#{SlackRubyBot.config.user} set units mi").to respond_with_slack_message(
-              "Activities for team #{team.name} now display *miles, feet, yards, and degrees Fahrenheit*."
+              "Activities for team #{team.name} now display *miles, feet, and yards*."
             )
             expect(client.owner.units).to eq 'mi'
             expect(team.reload.units).to eq 'mi'
@@ -240,7 +242,7 @@ describe SlackStrava::Commands::Set do
           it 'sets units to km' do
             team.update_attributes!(units: 'mi')
             expect(message: "#{SlackRubyBot.config.user} set units km").to respond_with_slack_message(
-              "Activities for team #{team.name} now display *kilometers, meters, and degrees Celsius*."
+              "Activities for team #{team.name} now display *kilometers and meters*."
             )
             expect(client.owner.units).to eq 'km'
             expect(team.reload.units).to eq 'km'
@@ -249,7 +251,7 @@ describe SlackStrava::Commands::Set do
           it 'sets units to metric' do
             team.update_attributes!(units: 'mi')
             expect(message: "#{SlackRubyBot.config.user} set units metric").to respond_with_slack_message(
-              "Activities for team #{team.name} now display *kilometers, meters, and degrees Celsius*."
+              "Activities for team #{team.name} now display *kilometers and meters*."
             )
             expect(client.owner.units).to eq 'km'
             expect(team.reload.units).to eq 'km'
@@ -258,7 +260,7 @@ describe SlackStrava::Commands::Set do
           it 'sets units to imperial' do
             team.update_attributes!(units: 'km')
             expect(message: "#{SlackRubyBot.config.user} set units imperial").to respond_with_slack_message(
-              "Activities for team #{team.name} now display *miles, feet, yards, and degrees Fahrenheit*."
+              "Activities for team #{team.name} now display *miles, feet, and yards*."
             )
             expect(client.owner.units).to eq 'mi'
             expect(team.reload.units).to eq 'mi'
@@ -267,7 +269,7 @@ describe SlackStrava::Commands::Set do
           it 'changes units' do
             team.update_attributes!(units: 'mi')
             expect(message: "#{SlackRubyBot.config.user} set units km").to respond_with_slack_message(
-              "Activities for team #{team.name} now display *kilometers, meters, and degrees Celsius*."
+              "Activities for team #{team.name} now display *kilometers and meters*."
             )
             expect(client.owner.units).to eq 'km'
             expect(team.reload.units).to eq 'km'
@@ -287,6 +289,58 @@ describe SlackStrava::Commands::Set do
             )
             expect(client.owner.units).to eq 'both'
             expect(team.reload.units).to eq 'both'
+          end
+        end
+
+        context 'temperature' do
+          it 'shows current value of temperature' do
+            expect(message: "#{SlackRubyBot.config.user} set temperature").to respond_with_slack_message(
+              "Activities for team #{team.name} display *degrees Fahrenheit*."
+            )
+          end
+
+          it 'sets temperature to f' do
+            team.update_attributes!(temperature: 'c')
+            expect(message: "#{SlackRubyBot.config.user} set temperature f").to respond_with_slack_message(
+              "Activities for team #{team.name} now display *degrees Fahrenheit*."
+            )
+            expect(team.reload.temperature).to eq 'f'
+          end
+
+          it 'sets temperature to c' do
+            expect(message: "#{SlackRubyBot.config.user} set temperature c").to respond_with_slack_message(
+              "Activities for team #{team.name} now display *degrees Celsius*."
+            )
+            expect(team.reload.temperature).to eq 'c'
+          end
+
+          it 'sets temperature to fahrenheit' do
+            team.update_attributes!(temperature: 'c')
+            expect(message: "#{SlackRubyBot.config.user} set temperature fahrenheit").to respond_with_slack_message(
+              "Activities for team #{team.name} now display *degrees Fahrenheit*."
+            )
+            expect(team.reload.temperature).to eq 'f'
+          end
+
+          it 'sets temperature to celsius' do
+            expect(message: "#{SlackRubyBot.config.user} set temperature celsius").to respond_with_slack_message(
+              "Activities for team #{team.name} now display *degrees Celsius*."
+            )
+            expect(team.reload.temperature).to eq 'c'
+          end
+
+          it 'sets temperature to both' do
+            expect(message: "#{SlackRubyBot.config.user} set temperature both").to respond_with_slack_message(
+              "Activities for team #{team.name} now display *degrees Fahrenheit and Celsius*."
+            )
+            expect(team.reload.temperature).to eq 'both'
+          end
+
+          it 'temperature can differ from units' do
+            team.update_attributes!(units: 'km', temperature: 'f')
+            expect(message: "#{SlackRubyBot.config.user} set temperature").to respond_with_slack_message(
+              "Activities for team #{team.name} display *degrees Fahrenheit*."
+            )
           end
         end
 
@@ -596,13 +650,13 @@ describe SlackStrava::Commands::Set do
             context 'units' do
               it 'shows team default in channel' do
                 expect(message: "#{SlackRubyBot.config.user} set units", channel: 'C1').to respond_with_slack_message(
-                  'Activities in <#C1> display *miles, feet, yards, and degrees Fahrenheit*.'
+                  'Activities in <#C1> display *miles, feet, and yards*.'
                 )
               end
 
               it 'sets units for channel' do
                 expect(message: "#{SlackRubyBot.config.user} set units km", channel: 'C1').to respond_with_slack_message(
-                  'Activities in <#C1> now display *kilometers, meters, and degrees Celsius*.'
+                  'Activities in <#C1> now display *kilometers and meters*.'
                 )
                 expect(team.reload.channel_units_for('C1')).to eq 'km'
                 expect(team.reload.units).to eq 'mi'
@@ -797,14 +851,14 @@ describe SlackStrava::Commands::Set do
           context 'units' do
             it 'shows current value of units' do
               expect(message: "#{SlackRubyBot.config.user} set units").to respond_with_slack_message(
-                "Activities for team #{team.name} display *miles, feet, yards, and degrees Fahrenheit*."
+                "Activities for team #{team.name} display *miles, feet, and yards*."
               )
             end
 
             it 'cannot set units' do
               team.update_attributes!(units: 'km')
               expect(message: "#{SlackRubyBot.config.user} set units mi").to respond_with_slack_message(
-                "Sorry, only <@#{team.activated_user_id}> or a Slack admin can change units. Activities for team #{team.name} display *kilometers, meters, and degrees Celsius*."
+                "Sorry, only <@#{team.activated_user_id}> or a Slack admin can change units. Activities for team #{team.name} display *kilometers and meters*."
               )
               expect(team.reload.units).to eq 'km'
             end


### PR DESCRIPTION
Fixes #138.

Adds `set temperature f|c|both` to control temperature units independently from distance units.

### Changes

- **Team** and **Channel** models gain a `temperature` field (default: `f`)
- Values: `f` (Fahrenheit), `c` (Celsius), `both` — also accepts `fahrenheit`/`celsius` aliases
- Works per-channel like other settings: channel overrides team default
- `units_s` no longer includes temperature — it is a separate display line in `set` output
- `weather_s` uses `effective_temperature` (respects channel override)

### Example

```
set units km          → distance in km/meters
set temperature f     → show °F regardless of distance units
set temperature c     → show °C
set temperature both  → show both °F and °C
```

### Migration

Run in the Rails console after deploying to set temperature based on each team's existing units setting:

```ruby
units_to_temp = { 'mi' => 'f', 'km' => 'c', 'both' => 'both' }

Team.each do |team|
  team.update_attributes!(temperature: units_to_temp[team.units] || 'f')
end

Channel.where(:units.ne => nil).each do |channel|
  channel.update_attributes!(temperature: units_to_temp[channel.units] || 'f')
end
```
