### PR TITLE
Add 'set threads activity' to post summary to channel with details in thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Changelog
 
+* 2026/04/19: Added `set threads activity` to post a summary to channel with full details in a thread reply, updating and deleting both messages as the activity changes - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
+* 2026/04/11: Added `set temperature f|c|both|auto` to control temperature units independently from distance units - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/11: Added `set temperature f|c|both|auto` to control temperature units independently from distance units - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/11: Return a 1x1 transparent pixel instead of a 404/403 error when activity maps are not found or have expired - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/11: Upgraded Ruby to 4.0.2, puma to 8.0.0, addressable to 2.9.0, stripe to 13.5.1, stripe-ruby-mock to 5.0.0 - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).

--- a/public/help.html.erb
+++ b/public/help.html.erb
@@ -98,6 +98,7 @@
     </p>
     <p>
       Thread posted activities daily, weekly or monthly with <b>set threads daily</b>, <b>set threads weekly</b> or <b>set threads monthly</b>.
+      Post a summary to the channel with full details in a thread reply using <b>set threads activity</b>.
       Remove threading with <b>set threads none</b> (default).
     </p>
     <p>

--- a/slack-strava/commands/help.rb
+++ b/slack-strava/commands/help.rb
@@ -7,44 +7,44 @@ module SlackStrava
 
         DM or /slava
         ------------
-        connect                                - connect your Strava account
-        disconnect                             - disconnect your Strava account
+        connect                                          - connect your Strava account
+        disconnect                                       - disconnect your Strava account
 
         Clubs
         ------------
-        /slava clubs                           - connect/disconnect clubs
+        /slava clubs                                     - connect/disconnect clubs
 
         Teams
         ------------
-        stats                                  - stats in current channel
-        leaderboard distance|... [when]        - leaderboard by distance, etc.
+        stats                                            - stats in current channel
+        leaderboard distance|... [when]                  - leaderboard by distance, etc.
           2025|last year|[month]|...
           since|between [date] [and [date]]
 
         Settings
         ------------
-        set retention [n] days|months|years    - set how long to retain user activities (default is 30 days)
-        set timezone [auto|tz]                 - set timezone, auto-detect from activities (default is auto)
-        set threads none|daily|weekly|monthly  - set activity threading (in channel overrides team default)
-        set userlimit [n]|none                 - max per user per day (in channel overrides team default)
-        set channellimit [n]|none              - max activities posted per channel per day (default is unlimited)
-        set units imperial|metric|both         - use imperial vs. metric units (in channel overrides team default)
-        set temperature f|c|both               - temperature units, independent of distance units (in channel overrides team default)
-        set fields all|none|...                - activity fields displayed (in channel overrides team default)
-        set maps off|full|thumb                - map display style (in channel overrides team default)
-        set leaderboard elapsed time|...       - change the default leaderboard
-        set activities all|run,ride,...        - set activity types posted in this channel (in channel, admin only)
-        set sync true|false                    - sync activities globally (in DM) or per channel (in channel)
-        set private true|false                 - sync private (only you) activities (default is false)
-        set followers true|false               - sync followers only activities (default is true)
+        set retention [n] days|months|years              - set how long to retain user activities (default is 30 days)
+        set timezone [auto|tz]                           - set timezone, auto-detect from activities (default is auto)
+        set threads none|daily|weekly|monthly|activity   - set activity threading (in channel overrides team default)
+        set userlimit [n]|none                           - max per user per day (in channel overrides team default)
+        set channellimit [n]|none                        - max activities posted per channel per day (default is unlimited)
+        set units imperial|metric|both                   - use imperial vs. metric units (in channel overrides team default)
+        set temperature f|c|both                         - temperature units, independent of distance units (in channel overrides team default)
+        set fields all|none|...                          - activity fields displayed (in channel overrides team default)
+        set maps off|full|thumb                          - map display style (in channel overrides team default)
+        set leaderboard elapsed time|...                 - change the default leaderboard
+        set activities all|run,ride,...                  - set activity types posted in this channel (in channel, admin only)
+        set sync true|false                              - sync activities globally (in DM) or per channel (in channel)
+        set private true|false                           - sync private (only you) activities (default is false)
+        set followers true|false                         - sync followers only activities (default is true)
 
         General
         ------------
-        help                                   - get this helpful message
-        subscription                           - show subscription info, update credit-card
-        unsubscribe                            - turn off subscription auto-renew
-        resubscribe                            - turn on subscription auto-renew
-        info                                   - bot info, contact, feature requests
+        help                                             - get this helpful message
+        subscription                                     - show subscription info, update credit-card
+        unsubscribe                                      - turn off subscription auto-renew
+        resubscribe                                      - turn on subscription auto-renew
+        info                                             - bot info, contact, feature requests
         ```
       EOS
       def self.call(client, data, _match)

--- a/slack-strava/models/channel.rb
+++ b/slack-strava/models/channel.rb
@@ -53,6 +53,7 @@ class Channel
     case threads
     when 'none' then 'displayed individually'
     when 'daily', 'weekly', 'monthly' then "rolled up in a #{threads} thread"
+    when 'activity' then 'posted with details in a thread'
     end
   end
 

--- a/slack-strava/models/channel_message.rb
+++ b/slack-strava/models/channel_message.rb
@@ -3,4 +3,5 @@ class ChannelMessage
 
   field :ts, type: String
   field :channel, type: String
+  field :details_ts, type: String
 end

--- a/slack-strava/models/club_activity.rb
+++ b/slack-strava/models/club_activity.rb
@@ -28,14 +28,7 @@ class ClubActivity < Activity
       nil
     else
       logger.info "Bragging about #{club}, #{self}"
-      message_with_channel = to_slack(club.channel_id).merge(channel: club.channel_id, as_user: true)
-      thread_ts = parent_thread(club.channel_id)
-      message_with_channel[:thread_ts] = thread_ts if thread_ts
-      logger.info "Posting '#{message_with_channel.to_json}' to #{club.team} on ##{club.channel_name}."
-      channel_message = club.team.slack_client.chat_postMessage(message_with_channel)
-      if channel_message
-        channel_message = { ts: channel_message['ts'], channel: club.channel_id }
-      end
+      channel_message = brag_to_channel!
       update_attributes!(bragged_at: Time.now.utc, channel_messages: [channel_message])
       [channel_message]
     end
@@ -108,18 +101,72 @@ class ClubActivity < Activity
     }
   end
 
-  def to_slack_blocks(channel_id = nil)
-    blocks = []
-    blocks << { type: 'section', text: { type: 'mrkdwn', text: "*<#{club.strava_url}|#{name || strava_id}>*" } }
-    blocks << {
-      type: 'context',
-      elements: [
-        { type: 'mrkdwn', text: "#{athlete_name} via #{club.name}" }
-      ]
+  def to_slack_summary(channel_id = nil)
+    {
+      blocks: to_slack_summary_blocks(channel_id),
+      attachments: []
     }
+  end
+
+  def to_slack_details(channel_id = nil)
+    {
+      blocks: to_slack_details_blocks(channel_id),
+      attachments: []
+    }
+  end
+
+  def to_slack_blocks(channel_id = nil)
+    to_slack_summary_blocks(channel_id) + to_slack_details_blocks(channel_id)
+  end
+
+  def to_slack_summary_blocks(_channel_id = nil)
+    [
+      { type: 'section', text: { type: 'mrkdwn', text: "*<#{club.strava_url}|#{name || strava_id}>*" } },
+      { type: 'context', elements: [{ type: 'mrkdwn', text: "#{athlete_name} via #{club.name}" }] }
+    ]
+  end
+
+  def to_slack_details_blocks(channel_id = nil)
     slack_fields_text = slack_fields_s(channel_id)
-    blocks << { type: 'section', text: { type: 'mrkdwn', text: slack_fields_text }, accessory: { type: 'image', image_url: club.logo, alt_text: club.name.to_s } } if slack_fields_text
-    blocks
+    return [] unless slack_fields_text
+
+    [{ type: 'section', text: { type: 'mrkdwn', text: slack_fields_text }, accessory: { type: 'image', image_url: club.logo, alt_text: club.name.to_s } }]
+  end
+
+  def brag_to_channel!
+    channel_id = club.channel_id
+    summary_with_channel = summary_message(channel_id).merge(channel: channel_id, as_user: true)
+    thread_ts = parent_thread(channel_id)
+    summary_with_channel[:thread_ts] = thread_ts if thread_ts
+    logger.info "Posting '#{summary_with_channel.to_json}' to #{club.team} on ##{club.channel_name}."
+    channel_message = club.team.slack_client.chat_postMessage(summary_with_channel)
+    if channel_message
+      ts = channel_message['ts']
+      channel_message = { ts: ts, channel: channel_id }
+      details = details_message(channel_id)
+      if details
+        details_with_channel = details.merge(channel: channel_id, as_user: true, thread_ts: ts)
+        logger.info "Posting details thread '#{details_with_channel.to_json}' to #{club.team} on ##{club.channel_name}."
+        details_rc = club.team.slack_client.chat_postMessage(details_with_channel)
+        channel_message[:details_ts] = details_rc['ts'] if details_rc
+      end
+    end
+    channel_message
+  end
+
+  def activity_thread?(channel_id)
+    team.channel_threads_for(channel_id) == 'activity'
+  end
+
+  def summary_message(channel_id)
+    activity_thread?(channel_id) ? to_slack_summary(channel_id) : to_slack(channel_id)
+  end
+
+  def details_message(channel_id)
+    return unless activity_thread?(channel_id)
+
+    msg = to_slack_details(channel_id)
+    msg if msg[:blocks].any?
   end
 
   def validate_team

--- a/slack-strava/models/team.rb
+++ b/slack-strava/models/team.rb
@@ -96,6 +96,8 @@ class Team
       'displayed individually'
     when 'daily', 'weekly', 'monthly'
       "rolled up in a #{threads} thread"
+    when 'activity'
+      'posted with details in a thread'
     else
       raise ArgumentError
     end

--- a/slack-strava/models/thread_types.rb
+++ b/slack-strava/models/thread_types.rb
@@ -5,6 +5,7 @@ class ThreadTypes
   define :DAILY, 'daily'
   define :WEEKLY, 'weekly'
   define :MONTHLY, 'monthly'
+  define :ACTIVITY, 'activity'
 
   def self.parse_s(s)
     return unless s

--- a/slack-strava/models/user.rb
+++ b/slack-strava/models/user.rb
@@ -172,6 +172,11 @@ class User
       message_with_channel = { channel: channel_message.channel, ts: channel_message.ts, as_user: true }
       logger.info "Deleting '#{message_with_channel.to_json}' to #{team} on ##{channel_message.channel}."
       team.slack_client.chat_delete(message_with_channel)
+      next unless channel_message.details_ts
+
+      details_with_channel = { channel: channel_message.channel, ts: channel_message.details_ts, as_user: true }
+      logger.info "Deleting details thread '#{details_with_channel.to_json}' to #{team} on ##{channel_message.channel}."
+      team.slack_client.chat_delete(details_with_channel)
     end
   end
 

--- a/slack-strava/models/user_activity.rb
+++ b/slack-strava/models/user_activity.rb
@@ -82,7 +82,7 @@ class UserActivity < Activity
                    next
                  end
                end
-               user.inform_channel!(to_slack(channel_id), channel, parent_thread(channel['id']))
+               brag_to_channel!(channel)
              }.flatten.compact
            else
              []
@@ -105,9 +105,7 @@ class UserActivity < Activity
     return unless channel_messages
 
     logger.info "Rebragging about #{user}, #{self}."
-    rc = channel_messages.map { |cm|
-      user.update!(to_slack(cm.channel), [cm]).first
-    }.compact
+    rc = channel_messages.map { |channel_message| rebrag_to_channel!(channel_message) }.compact
     update_attributes!(channel_messages: rc)
     rc
   end
@@ -147,6 +145,44 @@ class UserActivity < Activity
       timezone: response.timezone,
       photos: response.photos&.primary ? [Photo.summary_attrs_from_strava(response.photos&.primary)] : []
     }
+  end
+
+  def brag_to_channel!(channel)
+    channel_id = channel['id']
+    rc = user.inform_channel!(summary_message(channel_id), channel, parent_thread(channel_id))
+    details = details_message(channel_id)
+    if rc && details
+      details_rc = user.inform_channel!(details, channel, rc[:ts])
+      rc = rc.merge(details_ts: details_rc[:ts]) if details_rc
+    end
+    rc
+  end
+
+  def rebrag_to_channel!(channel_message)
+    channel_id = channel_message.channel
+    summary_rc = user.update!(summary_message(channel_id), [channel_message]).first
+    details = details_message(channel_id) if channel_message.details_ts
+    new_details_ts = if details
+                       msg = details.merge(channel: channel_id, ts: channel_message.details_ts, as_user: true)
+                       logger.info "Updating details thread '#{msg.to_json}' to #{user.team} on ##{channel_id}."
+                       user.team.slack_client.chat_update(msg)['ts']
+                     end
+    { ts: summary_rc[:ts], channel: channel_id, details_ts: new_details_ts }
+  end
+
+  def activity_thread?(channel_id)
+    team.channel_threads_for(channel_id) == 'activity'
+  end
+
+  def summary_message(channel_id)
+    activity_thread?(channel_id) ? to_slack_summary(channel_id) : to_slack(channel_id)
+  end
+
+  def details_message(channel_id)
+    return unless activity_thread?(channel_id)
+
+    msg = to_slack_details(channel_id)
+    msg if msg[:blocks].any?
   end
 
   def summary_attrs_from_strava(response)
@@ -281,6 +317,20 @@ class UserActivity < Activity
     }
   end
 
+  def to_slack_summary(channel_id = nil)
+    {
+      blocks: to_slack_summary_blocks(channel_id),
+      attachments: []
+    }
+  end
+
+  def to_slack_details(channel_id = nil)
+    {
+      blocks: to_slack_details_blocks(channel_id),
+      attachments: []
+    }
+  end
+
   # https://docs.slack.dev/reference/block-kit/composition-objects/text-object
   MAX_SLACK_TEXT_OBJECT_TEXT_LENGTH = 3000
 
@@ -291,10 +341,18 @@ class UserActivity < Activity
   end
 
   def to_slack_blocks(channel_id = nil)
-    blocks = []
+    to_slack_summary_blocks(channel_id) + to_slack_details_blocks(channel_id)
+  end
 
+  def to_slack_summary_blocks(channel_id = nil)
+    blocks = []
     blocks << { type: 'section', text: { type: 'mrkdwn', text: display_title_s(channel_id) } }
     blocks << context_block(channel_id) if display_field?(ActivityFields::MEDAL, channel_id) || display_field?(ActivityFields::ATHLETE, channel_id) || display_field?(ActivityFields::USER, channel_id) || display_field?(ActivityFields::DATE, channel_id)
+    blocks
+  end
+
+  def to_slack_details_blocks(channel_id = nil)
+    blocks = []
     blocks << { type: 'section', text: { type: 'plain_text', text: truncated_description, emoji: true } } if description && !description.blank? && display_field?(ActivityFields::DESCRIPTION, channel_id)
 
     fields_text = slack_fields_s(channel_id)

--- a/spec/models/club_activity_spec.rb
+++ b/spec/models/club_activity_spec.rb
@@ -83,6 +83,39 @@ describe ClubActivity do
       end
     end
 
+    context 'with activity threads' do
+      before do
+        team.update_attributes!(threads: 'activity')
+      end
+
+      it 'posts a summary to channel and details in a thread' do
+        expect(club.team.slack_client).to receive(:chat_postMessage).with(
+          activity.to_slack_summary.merge(
+            channel: club.channel_id,
+            as_user: true
+          )
+        ).and_return('ts' => 'summary_ts')
+        expect(club.team.slack_client).to receive(:chat_postMessage).with(
+          activity.to_slack_details.merge(
+            channel: club.channel_id,
+            as_user: true,
+            thread_ts: 'summary_ts'
+          )
+        ).and_return('ts' => 'details_ts')
+        expect(activity.brag!).to eq([{ ts: 'summary_ts', channel: club.channel_id, details_ts: 'details_ts' }])
+      end
+
+      it 'stores the summary and details ts in channel_messages' do
+        allow(club.team.slack_client).to receive(:chat_postMessage) do |args|
+          args[:thread_ts] ? { 'ts' => 'details_ts' } : { 'ts' => 'summary_ts' }
+        end
+        activity.brag!
+        cm = activity.channel_messages.first
+        expect(cm.ts).to eq 'summary_ts'
+        expect(cm.details_ts).to eq 'details_ts'
+      end
+    end
+
     it 'warns if the bot leaves the channel' do
       expect {
         expect_any_instance_of(Logger).to receive(:warn).with(/not_in_channel/)

--- a/spec/models/club_spec.rb
+++ b/spec/models/club_spec.rb
@@ -92,7 +92,7 @@ describe Club do
         activity = club.activities.create!(team: club.team, strava_id: '777e317fcba7e7c78d6ad584fd7219d8')
         tt = activity.reload.updated_at.utc
         activity2 = club2.activities.create!(team: club.team, strava_id: '777e317fcba7e7c78d6ad584fd7219d8')
-        tt2 = activity.reload.updated_at.utc
+        tt2 = activity2.reload.updated_at.utc
         Timecop.travel(Time.now + 1.hour)
         club.sync_new_strava_activities!
         expect(activity.reload.updated_at.utc.to_i).not_to eq(tt.to_i)

--- a/spec/models/user_activity_spec.rb
+++ b/spec/models/user_activity_spec.rb
@@ -232,6 +232,39 @@ describe UserActivity do
           end
         end
       end
+
+      context 'with activity threads' do
+        before do
+          team.update_attributes!(threads: 'activity')
+        end
+
+        it 'posts a summary to channel and details in a thread' do
+          expect(user.team.slack_client).to receive(:chat_postMessage).with(
+            activity.to_slack_summary.merge(
+              as_user: true,
+              channel: 'channel_id'
+            )
+          ).and_return('ts' => 'summary_ts')
+          expect(user.team.slack_client).to receive(:chat_postMessage).with(
+            activity.to_slack_details.merge(
+              as_user: true,
+              channel: 'channel_id',
+              thread_ts: 'summary_ts'
+            )
+          ).and_return('ts' => 'details_ts')
+          expect(activity.brag!).to eq([{ ts: 'summary_ts', channel: 'channel_id', details_ts: 'details_ts' }])
+        end
+
+        it 'stores the summary and details ts in channel_messages' do
+          allow(user.team.slack_client).to receive(:chat_postMessage) do |args|
+            args[:thread_ts] ? { 'ts' => 'details_ts' } : { 'ts' => 'summary_ts' }
+          end
+          activity.brag!
+          cm = activity.channel_messages.first
+          expect(cm.ts).to eq 'summary_ts'
+          expect(cm.details_ts).to eq 'details_ts'
+        end
+      end
     end
 
     context 'a deleted user' do
@@ -472,6 +505,80 @@ describe UserActivity do
       )
       activity.unbrag!
       expect(activity.reload.channel_messages).to eq []
+    end
+
+    context 'with activity threads' do
+      before do
+        activity.update_attributes!(
+          channel_messages: [
+            ChannelMessage.new(channel: 'channel_id', ts: 'summary_ts', details_ts: 'details_ts')
+          ]
+        )
+      end
+
+      it 'deletes both the summary and the details thread reply' do
+        expect(activity.user.team.slack_client).to receive(:chat_delete).with(
+          { channel: 'channel_id', ts: 'summary_ts', as_user: true }
+        )
+        expect(activity.user.team.slack_client).to receive(:chat_delete).with(
+          { channel: 'channel_id', ts: 'details_ts', as_user: true }
+        )
+        activity.unbrag!
+        expect(activity.reload.channel_messages).to eq []
+      end
+    end
+  end
+
+  context 'rebrag!' do
+    let(:team) { Fabricate(:team) }
+    let(:user) { Fabricate(:user, team: team) }
+    let!(:activity) { Fabricate(:user_activity, user: user) }
+
+    context 'with activity threads' do
+      before do
+        team.update_attributes!(threads: 'activity')
+        activity.update_attributes!(
+          bragged_at: Time.now.utc,
+          channel_messages: [
+            ChannelMessage.new(channel: 'channel_id', ts: 'summary_ts', details_ts: 'details_ts')
+          ]
+        )
+      end
+
+      it 'updates the summary message with summary content' do
+        expect(user.team.slack_client).to receive(:chat_update).with(
+          activity.to_slack_summary.merge(channel: 'channel_id', ts: 'summary_ts', as_user: true)
+        ).and_return('ts' => 'new_summary_ts')
+        expect(user.team.slack_client).to receive(:chat_update).with(
+          activity.to_slack_details.merge(channel: 'channel_id', ts: 'details_ts', as_user: true)
+        ).and_return('ts' => 'new_details_ts')
+        rc = activity.rebrag!
+        expect(rc).to eq([{ ts: 'new_summary_ts', channel: 'channel_id', details_ts: 'new_details_ts' }])
+      end
+
+      it 'persists updated ts values in channel_messages' do
+        allow(user.team.slack_client).to receive(:chat_update).and_return('ts' => 'new_ts')
+        activity.rebrag!
+        cm = activity.reload.channel_messages.first
+        expect(cm.ts).to eq 'new_ts'
+        expect(cm.details_ts).to eq 'new_ts'
+      end
+    end
+
+    context 'without activity threads' do
+      before do
+        activity.update_attributes!(
+          bragged_at: Time.now.utc,
+          channel_messages: [ChannelMessage.new(channel: 'channel_id', ts: 'ts')]
+        )
+      end
+
+      it 'updates with the full message' do
+        expect(user.team.slack_client).to receive(:chat_update).with(
+          activity.to_slack.merge(channel: 'channel_id', ts: 'ts', as_user: true)
+        ).and_return('ts' => 'new_ts')
+        activity.rebrag!
+      end
     end
   end
 

--- a/spec/slack-strava/commands/set_spec.rb
+++ b/spec/slack-strava/commands/set_spec.rb
@@ -405,6 +405,14 @@ describe SlackStrava::Commands::Set do
             end
           end
 
+          it 'sets threads to activity' do
+            team.update_attributes!(threads: 'none')
+            expect(message: "#{SlackRubyBot.config.user} set threads activity").to respond_with_slack_message(
+              "Activities for team #{team.name} are now *posted with details in a thread*."
+            )
+            expect(team.reload.threads).to eq 'activity'
+          end
+
           it 'sets threads to none' do
             team.update_attributes!(threads: 'daily')
             expect(message: "#{SlackRubyBot.config.user} set threads none").to respond_with_slack_message(
@@ -415,7 +423,7 @@ describe SlackStrava::Commands::Set do
 
           it 'displays an error for an invalid threads value' do
             expect(message: "#{SlackRubyBot.config.user} set threads foobar").to respond_with_slack_message(
-              'Invalid value: foobar, possible values are none, daily, weekly and monthly.'
+              'Invalid value: foobar, possible values are none, daily, weekly, monthly and activity.'
             )
             expect(team.reload.threads).to eq 'none'
           end
@@ -707,6 +715,14 @@ describe SlackStrava::Commands::Set do
                   'Activities in <#C1> are now *rolled up in a weekly thread*.'
                 )
                 expect(team.reload.channel_threads_for('C1')).to eq 'weekly'
+                expect(team.reload.threads).to eq 'none'
+              end
+
+              it 'sets threads to activity for channel' do
+                expect(message: "#{SlackRubyBot.config.user} set threads activity", channel: 'C1').to respond_with_slack_message(
+                  'Activities in <#C1> are now *posted with details in a thread*.'
+                )
+                expect(team.reload.channel_threads_for('C1')).to eq 'activity'
                 expect(team.reload.threads).to eq 'none'
               end
             end


### PR DESCRIPTION
Closes #65

## What

Adds a new `activity` option for `set threads`, which posts a compact summary to the channel and full details as a thread reply under it.

## Why

The existing `daily`/`weekly`/`monthly` thread modes group multiple activities into a single parent thread. This new mode creates a per-activity thread — keeping the channel clean while still surfacing all stats, maps, photos, and description via the thread.

## How

```
@bot set threads activity
```

- **Summary in channel:** title + athlete/date context block
- **Thread reply:** description, stats fields, map, photos


Works for both user activities and club activities.