### PR TITLE
Remove current_channel_id mutable accessor, pass channel_id explicitly

### DIFF
--- a/slack-strava/api/endpoints/requests/event.rb
+++ b/slack-strava/api/endpoints/requests/event.rb
@@ -53,7 +53,7 @@ module Api
               next
             end
 
-            unfurls = { link.url => { blocks: activity.to_slack_blocks } }
+            unfurls = { link.url => { blocks: activity.to_slack_blocks(event.channel) } }
             logger.info "UNFURL: #{link.url}, #{user}, #{activity}"
             logger.debug unfurls
 

--- a/slack-strava/models/activity_methods.rb
+++ b/slack-strava/models/activity_methods.rb
@@ -11,18 +11,16 @@ module ActivityMethods
     Windsurf Workout Yoga
   ].freeze
 
-  attr_accessor :current_channel_id
-
-  def effective_units
-    team.channel_units_for(current_channel_id)
+  def effective_units(channel_id = nil)
+    team.channel_units_for(channel_id)
   end
 
-  def effective_temperature
-    team.channel_temperature_for(current_channel_id)
+  def effective_temperature(channel_id = nil)
+    team.channel_temperature_for(channel_id)
   end
 
-  def effective_activity_fields
-    team.channel_activity_fields_for(current_channel_id)
+  def effective_activity_fields(channel_id = nil)
+    team.channel_activity_fields_for(channel_id)
   end
 
   #   field :name, type: String
@@ -74,15 +72,15 @@ module ActivityMethods
     format('%gkm', format('%.2f', distance_in_kilometers))
   end
 
-  def distance_s
+  def distance_s(channel_id = nil)
     if type == 'Swim'
-      case effective_units
+      case effective_units(channel_id)
       when 'km' then distance_in_meters_s
       when 'mi' then distance_in_yards_s
       when 'both' then [distance_in_yards_s, distance_in_meters_s].join(UNIT_SEPARATOR)
       end
     else
-      case effective_units
+      case effective_units(channel_id)
       when 'km' then distance_in_kilometers_s
       when 'mi' then distance_in_miles_s
       when 'both' then [distance_in_miles_s, distance_in_kilometers_s].join(UNIT_SEPARATOR)
@@ -158,24 +156,24 @@ module ActivityMethods
     format('%gft', format('%.1f', total_elevation_gain_in_feet))
   end
 
-  def total_elevation_gain_s
-    case effective_units
+  def total_elevation_gain_s(channel_id = nil)
+    case effective_units(channel_id)
     when 'km' then total_elevation_gain_in_meters_s
     when 'mi' then total_elevation_gain_in_feet_s
     when 'both' then [total_elevation_gain_in_feet_s, total_elevation_gain_in_meters_s].join(UNIT_SEPARATOR)
     end
   end
 
-  def pace_s
+  def pace_s(channel_id = nil)
     case type
     when 'Swim'
-      case effective_units
+      case effective_units(channel_id)
       when 'km' then pace_per_100_meters_s
       when 'mi' then pace_per_100_yards_s
       when 'both' then [pace_per_100_yards_s, pace_per_100_meters_s].join(UNIT_SEPARATOR)
       end
     else
-      case effective_units
+      case effective_units(channel_id)
       when 'km' then pace_per_kilometer_s
       when 'mi' then pace_per_mile_s
       when 'both' then [pace_per_mile_s, pace_per_kilometer_s].join(UNIT_SEPARATOR)
@@ -183,16 +181,16 @@ module ActivityMethods
     end
   end
 
-  def speed_s
-    case effective_units
+  def speed_s(channel_id = nil)
+    case effective_units(channel_id)
     when 'km' then kilometer_per_hour_s
     when 'mi' then miles_per_hour_s
     when 'both' then [miles_per_hour_s, kilometer_per_hour_s].join(UNIT_SEPARATOR)
     end
   end
 
-  def max_speed_s
-    case effective_units
+  def max_speed_s(channel_id = nil)
+    case effective_units(channel_id)
     when 'km' then max_kilometer_per_hour_s
     when 'mi' then max_miles_per_hour_s
     when 'both' then [max_miles_per_hour_s, max_kilometer_per_hour_s].join(UNIT_SEPARATOR)
@@ -282,8 +280,8 @@ module ActivityMethods
     ].compact.join
   end
 
-  def display_field?(name)
-    activity_fields = effective_activity_fields
+  def display_field?(name, channel_id = nil)
+    activity_fields = effective_activity_fields(channel_id)
 
     case activity_fields
     when ['All']
@@ -297,8 +295,8 @@ module ActivityMethods
     end
   end
 
-  def slack_fields
-    activity_fields = effective_activity_fields
+  def slack_fields(channel_id = nil)
+    activity_fields = effective_activity_fields(channel_id)
 
     case activity_fields
     when ['All']
@@ -315,7 +313,7 @@ module ActivityMethods
       when 'Type'
         fields << { title: 'Type', value: type_with_emoji, short: true }
       when 'Distance'
-        fields << { title: 'Distance', value: distance_s, short: true } if distance&.positive?
+        fields << { title: 'Distance', value: distance_s(channel_id), short: true } if distance&.positive?
       when 'Time'
         if elapsed_time&.positive? && moving_time&.positive?
           fields << { title: 'Time', value: moving_time_in_hours_s, short: true } if elapsed_time == moving_time
@@ -329,13 +327,13 @@ module ActivityMethods
       when 'Elapsed Time'
         fields << { title: 'Elapsed Time', value: elapsed_time_in_hours_s, short: true } if elapsed_time&.positive? && moving_time&.positive? && elapsed_time != moving_time
       when 'Pace'
-        fields << { title: 'Pace', value: pace_s, short: true } if average_speed&.positive?
+        fields << { title: 'Pace', value: pace_s(channel_id), short: true } if average_speed&.positive?
       when 'Speed'
-        fields << { title: 'Speed', value: speed_s, short: true } if average_speed&.positive?
+        fields << { title: 'Speed', value: speed_s(channel_id), short: true } if average_speed&.positive?
       when 'Max Speed'
-        fields << { title: 'Max Speed', value: max_speed_s, short: true } if max_speed&.positive?
+        fields << { title: 'Max Speed', value: max_speed_s(channel_id), short: true } if max_speed&.positive?
       when 'Elevation'
-        fields << { title: 'Elevation', value: total_elevation_gain_s, short: true } if total_elevation_gain&.positive?
+        fields << { title: 'Elevation', value: total_elevation_gain_s(channel_id), short: true } if total_elevation_gain&.positive?
       when 'Heart Rate'
         fields << { title: 'Heart Rate', value: average_heartrate_s, short: true } if average_heartrate&.positive?
       when 'Max Heart Rate'
@@ -345,7 +343,7 @@ module ActivityMethods
       when 'Calories'
         fields << { title: 'Calories', value: calories_s, short: true } if calories&.positive?
       when 'Weather'
-        fields << { title: 'Weather', value: weather_s, short: true } if respond_to?(:weather) && weather.present?
+        fields << { title: 'Weather', value: weather_s(channel_id), short: true } if respond_to?(:weather) && weather.present?
       when 'Device'
         fields << { title: 'Device', value: device, short: true } if device && !device.blank?
       when 'Gear'
@@ -355,8 +353,8 @@ module ActivityMethods
     fields.any? ? fields : nil
   end
 
-  def slack_fields_s
-    fields = slack_fields
+  def slack_fields_s(channel_id = nil)
+    fields = slack_fields(channel_id)
     return unless fields&.any?
 
     fields.map { |block|

--- a/slack-strava/models/activity_summary.rb
+++ b/slack-strava/models/activity_summary.rb
@@ -32,7 +32,7 @@ class ActivitySummary
     [type.pluralize, emoji].compact.join(' ')
   end
 
-  def slack_fields
+  def slack_fields(channel_id = nil)
     [
       { short: true, title: type_with_emoji, value: count.to_s },
       { short: true, title: 'Athletes', value: athlete_count.to_s }

--- a/slack-strava/models/club_activity.rb
+++ b/slack-strava/models/club_activity.rb
@@ -28,7 +28,7 @@ class ClubActivity < Activity
       nil
     else
       logger.info "Bragging about #{club}, #{self}"
-      message_with_channel = to_slack.merge(channel: club.channel_id, as_user: true)
+      message_with_channel = to_slack(club.channel_id).merge(channel: club.channel_id, as_user: true)
       thread_ts = parent_thread(club.channel_id)
       message_with_channel[:thread_ts] = thread_ts if thread_ts
       logger.info "Posting '#{message_with_channel.to_json}' to #{club.team} on ##{club.channel_name}."
@@ -101,14 +101,14 @@ class ClubActivity < Activity
     ary.any? ? ary.join(' on ') : nil
   end
 
-  def to_slack
+  def to_slack(channel_id = nil)
     {
-      blocks: to_slack_blocks,
+      blocks: to_slack_blocks(channel_id),
       attachments: []
     }
   end
 
-  def to_slack_blocks
+  def to_slack_blocks(channel_id = nil)
     blocks = []
     blocks << { type: 'section', text: { type: 'mrkdwn', text: "*<#{club.strava_url}|#{name || strava_id}>*" } }
     blocks << {
@@ -117,7 +117,7 @@ class ClubActivity < Activity
         { type: 'mrkdwn', text: "#{athlete_name} via #{club.name}" }
       ]
     }
-    slack_fields_text = slack_fields_s
+    slack_fields_text = slack_fields_s(channel_id)
     blocks << { type: 'section', text: { type: 'mrkdwn', text: slack_fields_text }, accessory: { type: 'image', image_url: club.logo, alt_text: club.name.to_s } } if slack_fields_text
     blocks
   end

--- a/slack-strava/models/user_activity.rb
+++ b/slack-strava/models/user_activity.rb
@@ -82,10 +82,7 @@ class UserActivity < Activity
                    next
                  end
                end
-               self.current_channel_id = channel_id
-               message = to_slack
-               self.current_channel_id = nil
-               user.inform_channel!(message, channel, parent_thread(channel['id']))
+               user.inform_channel!(to_slack(channel_id), channel, parent_thread(channel['id']))
              }.flatten.compact
            else
              []
@@ -108,7 +105,9 @@ class UserActivity < Activity
     return unless channel_messages
 
     logger.info "Rebragging about #{user}, #{self}."
-    rc = user.update!(to_slack, channel_messages)
+    rc = channel_messages.map { |cm|
+      user.update!(to_slack(cm.channel), [cm]).first
+    }.compact
     update_attributes!(channel_messages: rc)
     rc
   end
@@ -203,50 +202,50 @@ class UserActivity < Activity
     activity
   end
 
-  def display_title_s
-    if display_field?(ActivityFields::TITLE) && display_field?(ActivityFields::URL)
+  def display_title_s(channel_id = nil)
+    if display_field?(ActivityFields::TITLE, channel_id) && display_field?(ActivityFields::URL, channel_id)
       if /\p{Emoji_Presentation}/ =~ name
         "*#{name}* <#{strava_url}|…>"
       else
         "*<#{strava_url}|#{name || strava_id}>*"
       end
-    elsif display_field?(ActivityFields::TITLE)
+    elsif display_field?(ActivityFields::TITLE, channel_id)
       "*#{name || strava_id}*"
-    elsif display_field?(ActivityFields::URL)
+    elsif display_field?(ActivityFields::URL, channel_id)
       "*<#{strava_url}|#{strava_id}>*"
     end
   end
 
-  def display_medal_s
-    return unless display_field?(ActivityFields::MEDAL)
+  def display_medal_s(channel_id = nil)
+    return unless display_field?(ActivityFields::MEDAL, channel_id)
 
     user.medal_s(type)
   end
 
-  def display_user_s
-    return unless display_field?(ActivityFields::USER)
+  def display_user_s(channel_id = nil)
+    return unless display_field?(ActivityFields::USER, channel_id)
 
     "<@#{user.user_name}>"
   end
 
-  def display_user_with_medal_s
+  def display_user_with_medal_s(channel_id = nil)
     ary = [
-      display_athlete_s,
-      display_user_s,
-      display_medal_s
+      display_athlete_s(channel_id),
+      display_user_s(channel_id),
+      display_medal_s(channel_id)
     ].compact
 
     ary.any? ? ary.join(' ') : nil
   end
 
-  def display_date_s
-    return unless display_field?(ActivityFields::DATE)
+  def display_date_s(channel_id = nil)
+    return unless display_field?(ActivityFields::DATE, channel_id)
 
     start_date_local_s
   end
 
-  def display_athlete_s
-    return unless display_field?(ActivityFields::ATHLETE) && user.athlete
+  def display_athlete_s(channel_id = nil)
+    return unless display_field?(ActivityFields::ATHLETE, channel_id) && user.athlete
 
     if /\p{Emoji_Presentation}/ =~ user.athlete.name
       "#{user.athlete.name} <#{user.athlete.strava_url}|…>"
@@ -255,19 +254,19 @@ class UserActivity < Activity
     end
   end
 
-  def display_context_s
+  def display_context_s(channel_id = nil)
     ary = [
-      display_user_with_medal_s,
-      display_date_s
+      display_user_with_medal_s(channel_id),
+      display_date_s(channel_id)
     ].compact
 
     ary.any? ? ary.join(' on ') : nil
   end
 
-  def context_block
+  def context_block(channel_id = nil)
     elements = []
-    elements << { type: 'image', image_url: user.athlete.profile_medium, alt_text: user.athlete.name.to_s } if user.athlete && display_field?(ActivityFields::ATHLETE)
-    elements << { type: 'mrkdwn', text: display_context_s }
+    elements << { type: 'image', image_url: user.athlete.profile_medium, alt_text: user.athlete.name.to_s } if user.athlete && display_field?(ActivityFields::ATHLETE, channel_id)
+    elements << { type: 'mrkdwn', text: display_context_s(channel_id) }
 
     {
       type: 'context',
@@ -275,9 +274,9 @@ class UserActivity < Activity
     }
   end
 
-  def to_slack
+  def to_slack(channel_id = nil)
     {
-      blocks: to_slack_blocks,
+      blocks: to_slack_blocks(channel_id),
       attachments: []
     }
   end
@@ -291,15 +290,15 @@ class UserActivity < Activity
     "#{description[0...(MAX_SLACK_TEXT_OBJECT_TEXT_LENGTH - 2)]} …"
   end
 
-  def to_slack_blocks
+  def to_slack_blocks(channel_id = nil)
     blocks = []
 
-    blocks << { type: 'section', text: { type: 'mrkdwn', text: display_title_s } }
-    blocks << context_block if display_field?(ActivityFields::MEDAL) || display_field?(ActivityFields::ATHLETE) || display_field?(ActivityFields::USER) || display_field?(ActivityFields::DATE)
-    blocks << { type: 'section', text: { type: 'plain_text', text: truncated_description, emoji: true } } if description && !description.blank? && display_field?(ActivityFields::DESCRIPTION)
+    blocks << { type: 'section', text: { type: 'mrkdwn', text: display_title_s(channel_id) } }
+    blocks << context_block(channel_id) if display_field?(ActivityFields::MEDAL, channel_id) || display_field?(ActivityFields::ATHLETE, channel_id) || display_field?(ActivityFields::USER, channel_id) || display_field?(ActivityFields::DATE, channel_id)
+    blocks << { type: 'section', text: { type: 'plain_text', text: truncated_description, emoji: true } } if description && !description.blank? && display_field?(ActivityFields::DESCRIPTION, channel_id)
 
-    fields_text = slack_fields_s
-    effective_maps = team.channel_maps_for(current_channel_id)
+    fields_text = slack_fields_s(channel_id)
+    effective_maps = team.channel_maps_for(channel_id)
     if map&.polyline? && effective_maps == 'full'
       blocks << { type: 'section', text: { type: 'mrkdwn', text: fields_text } } if fields_text
       blocks << { type: 'image', image_url: map.proxy_image_url, alt_text: '' }
@@ -309,7 +308,7 @@ class UserActivity < Activity
       blocks << { type: 'section', text: { type: 'mrkdwn', text: fields_text } }
     end
 
-    blocks.concat(photos.map(&:to_slack)) if display_field?(ActivityFields::PHOTOS) && photos.any?
+    blocks.concat(photos.map(&:to_slack)) if display_field?(ActivityFields::PHOTOS, channel_id) && photos.any?
 
     blocks
   end
@@ -363,7 +362,7 @@ class UserActivity < Activity
     logger.warn "Error getting weather at #{start_latlng.join(', ')} on #{finished_at.to_i} for #{user}, #{self}, #{e.message}."
   end
 
-  def weather_s
+  def weather_s(channel_id = nil)
     return unless weather.present?
 
     current_weather = OpenWeather::Models::OneCall::CurrentWeather.new(
@@ -372,7 +371,7 @@ class UserActivity < Activity
 
     main = current_weather.weather&.first&.main
 
-    case effective_temperature
+    case effective_temperature(channel_id)
     when 'c' then
       ["#{current_weather.temp_c.to_i}°C", main].compact.join(' ')
     when 'f' then

--- a/spec/models/user_activity_spec.rb
+++ b/spec/models/user_activity_spec.rb
@@ -404,22 +404,22 @@ describe UserActivity do
 
     it 'displays the title only' do
       activity = Fabricate(:user_activity, name: 'Test Activity', strava_id: '123')
-      allow(activity).to receive(:display_field?).with(ActivityFields::URL).and_return(false)
-      allow(activity).to receive(:display_field?).with(ActivityFields::TITLE).and_return(true)
+      allow(activity).to receive(:display_field?).with(ActivityFields::URL, nil).and_return(false)
+      allow(activity).to receive(:display_field?).with(ActivityFields::TITLE, nil).and_return(true)
       expect(activity.display_title_s).to eq('*Test Activity*')
     end
 
     it 'displays the URL with ID only' do
       activity = Fabricate(:user_activity, name: 'Test Activity', strava_id: '123')
-      allow(activity).to receive(:display_field?).with(ActivityFields::URL).and_return(true)
-      allow(activity).to receive(:display_field?).with(ActivityFields::TITLE).and_return(false)
+      allow(activity).to receive(:display_field?).with(ActivityFields::URL, nil).and_return(true)
+      allow(activity).to receive(:display_field?).with(ActivityFields::TITLE, nil).and_return(false)
       expect(activity.display_title_s).to eq('*<https://www.strava.com/activities/123|123>*')
     end
 
     it 'displays neither' do
       activity = Fabricate(:user_activity, name: 'Test Activity', strava_id: '123')
-      allow(activity).to receive(:display_field?).with(ActivityFields::URL).and_return(false)
-      allow(activity).to receive(:display_field?).with(ActivityFields::TITLE).and_return(false)
+      allow(activity).to receive(:display_field?).with(ActivityFields::URL, nil).and_return(false)
+      allow(activity).to receive(:display_field?).with(ActivityFields::TITLE, nil).and_return(false)
       expect(activity.display_title_s).to be_nil
     end
   end


### PR DESCRIPTION
Replaces the `attr_accessor :current_channel_id` pattern — where callers had to set/nil an instance variable around rendering calls — with an explicit `channel_id = nil` parameter threaded through the rendering call chain.

## Changes

- `ActivityMethods`: `effective_units`, `effective_temperature`, `effective_activity_fields`, `distance_s`, `pace_s`, `speed_s`, `max_speed_s`, `total_elevation_gain_s`, `display_field?`, `slack_fields`, `slack_fields_s` all accept `channel_id = nil`
- `ActivitySummary#slack_fields` forwards `channel_id` to `super`
- `UserActivity`: all `display_*` helpers, `context_block`, `to_slack_blocks`, `to_slack`, `weather_s` accept `channel_id = nil`
- `event.rb` unfurl now passes `event.channel` for per-channel rendering

All callers default to `nil` (team-level settings), so there is no behavior change for code paths without a channel context. Existing tests required no changes except updating RSpec stubs for `display_field?` that matched on a single argument.