### PR TITLE
Fix activity thread summary posting into existing thread instead of top-level

### DIFF
--- a/slack-strava/models/activity.rb
+++ b/slack-strava/models/activity.rb
@@ -81,7 +81,7 @@ class Activity
   # Look for the last activity thread.
   def parent_thread(channel_id, timestamp_field = :bragged_at, now = nil)
     effective_threads = team.channel_threads_for(channel_id)
-    return if effective_threads.nil? || effective_threads == 'none'
+    return if effective_threads.nil? || %w[none activity].include?(effective_threads)
 
     now ||= Time.now.utc
 

--- a/spec/models/club_activity_spec.rb
+++ b/spec/models/club_activity_spec.rb
@@ -114,6 +114,31 @@ describe ClubActivity do
         expect(cm.ts).to eq 'summary_ts'
         expect(cm.details_ts).to eq 'details_ts'
       end
+
+      context 'with an existing thread parent in activity thread mode' do
+        let!(:thread_parent) do
+          Fabricate(
+            :club_activity,
+            club: club,
+            distance: 123,
+            bragged_at: Time.now.utc,
+            channel_messages: [
+              ChannelMessage.new(ts: 'ts', channel: club.channel_id)
+            ]
+          )
+        end
+
+        it 'posts the summary to the top-level channel, not into the existing thread' do
+          expect(club.team.slack_client).to receive(:chat_postMessage).with(
+            activity.to_slack_summary.merge(
+              channel: club.channel_id,
+              as_user: true
+            )
+          ).and_return('ts' => 'summary_ts')
+          allow(club.team.slack_client).to receive(:chat_postMessage).and_return('ts' => 'details_ts')
+          activity.brag!
+        end
+      end
     end
 
     it 'warns if the bot leaves the channel' do

--- a/spec/models/user_activity_spec.rb
+++ b/spec/models/user_activity_spec.rb
@@ -264,6 +264,30 @@ describe UserActivity do
           expect(cm.ts).to eq 'summary_ts'
           expect(cm.details_ts).to eq 'details_ts'
         end
+
+        context 'with an existing thread parent in activity thread mode' do
+          let!(:thread_parent) do
+            Fabricate(
+              :user_activity,
+              user: user,
+              bragged_at: Time.now.utc,
+              channel_messages: [
+                ChannelMessage.new(ts: 'ts', channel: 'channel_id')
+              ]
+            )
+          end
+
+          it 'posts the summary to the top-level channel, not into the existing thread' do
+            expect(user.team.slack_client).to receive(:chat_postMessage).with(
+              activity.to_slack_summary.merge(
+                as_user: true,
+                channel: 'channel_id'
+              )
+            ).and_return('ts' => 'summary_ts')
+            allow(user.team.slack_client).to receive(:chat_postMessage).and_return('ts' => 'details_ts')
+            activity.brag!
+          end
+        end
       end
     end
 


### PR DESCRIPTION
When `set threads activity` is enabled and the team also has daily/weekly threads configured, the activity summary was incorrectly posted into the existing daily/weekly thread instead of top-level in the channel, making it invisible. The details reply then threaded off that buried message.

Fix: pass `nil` as `thread_ts` for the summary post when in activity thread mode.