### PR TITLE
Rebrag preserves original thread mode based on stored details_ts

### DIFF
--- a/slack-strava/models/user_activity.rb
+++ b/slack-strava/models/user_activity.rb
@@ -160,14 +160,15 @@ class UserActivity < Activity
 
   def rebrag_to_channel!(channel_message)
     channel_id = channel_message.channel
-    summary_rc = user.update!(summary_message(channel_id), [channel_message]).first
-    details = details_message(channel_id) if channel_message.details_ts
-    new_details_ts = if details
-                       msg = details.merge(channel: channel_id, ts: channel_message.details_ts, as_user: true)
-                       logger.info "Updating details thread '#{msg.to_json}' to #{user.team} on ##{channel_id}."
-                       user.team.slack_client.chat_update(msg)['ts']
-                     end
-    { ts: summary_rc[:ts], channel: channel_id, details_ts: new_details_ts }
+    if channel_message.details_ts
+      summary_rc = user.update!(to_slack_summary(channel_id), [channel_message]).first
+      details_msg = to_slack_details(channel_id).merge(channel: channel_id, ts: channel_message.details_ts, as_user: true)
+      logger.info "Updating details thread '#{details_msg.to_json}' to #{user.team} on ##{channel_id}."
+      new_details_ts = user.team.slack_client.chat_update(details_msg)['ts']
+      { ts: summary_rc[:ts], channel: channel_id, details_ts: new_details_ts }
+    else
+      user.update!(to_slack(channel_id), [channel_message]).first
+    end
   end
 
   def activity_thread?(channel_id)

--- a/spec/models/user_activity_spec.rb
+++ b/spec/models/user_activity_spec.rb
@@ -604,6 +604,47 @@ describe UserActivity do
         activity.rebrag!
       end
     end
+
+    context 'originally bragged without activity threads, now switched to activity threads' do
+      before do
+        team.update_attributes!(threads: 'activity')
+        activity.update_attributes!(
+          bragged_at: Time.now.utc,
+          channel_messages: [ChannelMessage.new(channel: 'channel_id', ts: 'ts')]
+        )
+      end
+
+      it 'rebrags using the original non-activity thread mode' do
+        expect(user.team.slack_client).to receive(:chat_update).with(
+          activity.to_slack.merge(channel: 'channel_id', ts: 'ts', as_user: true)
+        ).and_return('ts' => 'new_ts')
+        rc = activity.rebrag!
+        expect(rc).to eq([{ ts: 'new_ts', channel: 'channel_id' }])
+      end
+    end
+
+    context 'originally bragged with activity threads, now switched to non-activity threads' do
+      before do
+        team.update_attributes!(threads: 'none')
+        activity.update_attributes!(
+          bragged_at: Time.now.utc,
+          channel_messages: [
+            ChannelMessage.new(channel: 'channel_id', ts: 'summary_ts', details_ts: 'details_ts')
+          ]
+        )
+      end
+
+      it 'rebrags using the original activity thread mode' do
+        expect(user.team.slack_client).to receive(:chat_update).with(
+          activity.to_slack_summary.merge(channel: 'channel_id', ts: 'summary_ts', as_user: true)
+        ).and_return('ts' => 'new_summary_ts')
+        expect(user.team.slack_client).to receive(:chat_update).with(
+          activity.to_slack_details.merge(channel: 'channel_id', ts: 'details_ts', as_user: true)
+        ).and_return('ts' => 'new_details_ts')
+        rc = activity.rebrag!
+        expect(rc).to eq([{ ts: 'new_summary_ts', channel: 'channel_id', details_ts: 'new_details_ts' }])
+      end
+    end
   end
 
   context 'miles' do


### PR DESCRIPTION
When rebragging an activity, use the thread mode it was originally posted with (indicated by `details_ts` presence) rather than the current `threads` setting. This means mode changes only take effect on new activities, not rebrags of existing ones.