### PR TITLE
Raise descriptive error when Slack OAuth returns ok: false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Changelog
 
+* 2026/04/20: Raise a descriptive error when Slack OAuth returns `ok: false`, or when an Enterprise Grid install is attempted - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/20: Extended `stats` command to accept date expressions: year (e.g. `stats 2024`), period aliases (`weekly`, `monthly`, `quarterly`, `yearly`), and natural language ranges (e.g. `stats since January`, `stats last week`) - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/19: Automatically display pace for run/walk/swim/hike activities and speed for ride/bike activities when using default fields - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/19: Added `set threads activity` to post a summary to channel with full details in a thread reply, updating and deleting both messages as the activity changes - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).

--- a/slack-strava/api/endpoints/teams_endpoint.rb
+++ b/slack-strava/api/endpoints/teams_endpoint.rb
@@ -46,6 +46,9 @@ module Api
             code: params[:code]
           )
 
+          raise rc['error'] || 'invalid OAuth response' unless rc['ok']
+          raise 'Enterprise Grid is not supported.' if rc['ok'] && rc['team_id'].nil?
+
           token = rc['bot']['bot_access_token']
           bot_user_id = rc['bot']['bot_user_id']
           user_id = rc['user_id']

--- a/spec/api/endpoints/teams_endpoint_spec.rb
+++ b/spec/api/endpoints/teams_endpoint_spec.rb
@@ -35,6 +35,7 @@ describe Api::Endpoints::TeamsEndpoint do
     context 'register' do
       before do
         oauth_access = {
+          'ok' => true,
           'bot' => {
             'bot_access_token' => 'token',
             'bot_user_id' => 'bot_user_id'
@@ -139,6 +140,56 @@ describe Api::Endpoints::TeamsEndpoint do
         expect { client.teams._post(code: 'code') }.to raise_error Faraday::ClientError do |e|
           json = JSON.parse(e.response[:body])
           expect(json['message']).to eq "Team #{existing_team.name} is already registered."
+        end
+      end
+
+      context 'when oauth returns an error' do
+        before do
+          allow_any_instance_of(Slack::Web::Client).to receive(:oauth_access).and_return(
+            'ok' => false,
+            'error' => 'invalid_code'
+          )
+        end
+
+        it 'raises the error' do
+          expect { client.teams._post(code: 'bad_code') }.to raise_error Faraday::ClientError do |e|
+            json = JSON.parse(e.response[:body])
+            expect(json['message']).to eq 'invalid_code'
+          end
+        end
+      end
+
+      context 'when oauth returns ok: false without an error message' do
+        before do
+          allow_any_instance_of(Slack::Web::Client).to receive(:oauth_access).and_return(
+            'ok' => false
+          )
+        end
+
+        it 'raises an invalid OAuth response error' do
+          expect { client.teams._post(code: 'bad_code') }.to raise_error Faraday::ClientError do |e|
+            json = JSON.parse(e.response[:body])
+            expect(json['message']).to eq 'invalid OAuth response'
+          end
+        end
+      end
+
+      context 'when oauth returns an enterprise grid response without a team_id' do
+        before do
+          allow_any_instance_of(Slack::Web::Client).to receive(:oauth_access).and_return(
+            'ok' => true,
+            'access_token' => 'xoxb-enterprise',
+            'team_id' => nil,
+            'enterprise_id' => 'E123',
+            'enterprise_name' => 'My Enterprise'
+          )
+        end
+
+        it 'raises an enterprise not supported error' do
+          expect { client.teams._post(code: 'code') }.to raise_error Faraday::ClientError do |e|
+            json = JSON.parse(e.response[:body])
+            expect(json['message']).to eq 'Enterprise Grid is not supported.'
+          end
         end
       end
 

--- a/spec/integration/teams_spec.rb
+++ b/spec/integration/teams_spec.rb
@@ -17,7 +17,7 @@ describe 'Teams', :js, type: :feature do
     it 'registers a team' do
       allow_any_instance_of(Team).to receive(:ping!).and_return(ok: true)
       expect(SlackRubyBotServer::Service.instance).to receive(:start!)
-      oauth_access = { 'bot' => { 'bot_access_token' => 'token' }, 'team_id' => 'team_id', 'team_name' => 'team_name' }
+      oauth_access = { 'ok' => true, 'bot' => { 'bot_access_token' => 'token' }, 'team_id' => 'team_id', 'team_name' => 'team_name' }
       allow_any_instance_of(Slack::Web::Client).to receive(:oauth_access).with(hash_including(code: 'code')).and_return(oauth_access)
       expect {
         visit '/?code=code'


### PR DESCRIPTION
## What

When Slack's `oauth.access` returns an error response (e.g. `invalid_code`, `bad_client_secret`), the code was crashing with a `NoMethodError` at `rc['bot']['bot_access_token']` because `rc['bot']` is `nil` in error responses.

## Why

The OAuth callback handler never checked `rc['ok']` before accessing nested fields, so any Slack error response (expired/reused code, bad credentials, etc.) caused an unhandled nil dereference instead of a clean error.

## How

Added `raise rc['error'] || 'invalid OAuth response' unless rc['ok']` immediately after the OAuth API call. Also added a check for Enterprise Grid installs (where `team_id` is nil). Added `'ok' => true` to existing test mocks and new tests covering the error paths.

Ported from https://github.com/dblock/slack-sup2/pull/121.