### PR TITLE
Fixed Team#subscription_info failing with NoMethodError on Stripe::Customer#sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Changelog
 
+* 2026/05/02: Fixed `Team#subscription_info` failing with `NoMethodError: undefined method 'sources'` on `Stripe::Customer` in stripe 13.5.1 by using `Stripe::Customer.list_sources` - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/20: Raise a descriptive error when Slack OAuth returns `ok: false`, or when an Enterprise Grid install is attempted - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/20: Extended `stats` command to accept date expressions: year (e.g. `stats 2024`), period aliases (`weekly`, `monthly`, `quarterly`, `yearly`), and natural language ranges (e.g. `stats since January`, `stats last week`) - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/19: Automatically display pace for run/walk/swim/hike activities and speed for ride/bike activities when using default fields - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).

--- a/slack-strava/models/team.rb
+++ b/slack-strava/models/team.rb
@@ -333,7 +333,7 @@ class Team
   end
 
   def stripe_customer_sources_info
-    stripe_customer.sources.map do |source|
+    Stripe::Customer.list_sources(stripe_customer.id).map do |source|
       case source.object
       when 'card'
         "On file #{source.brand} #{source.object}, #{source.name} ending with #{source.last4}, expires #{source.exp_month}/#{source.exp_year}."

--- a/spec/slack-strava/commands/subscription_spec.rb
+++ b/spec/slack-strava/commands/subscription_spec.rb
@@ -44,7 +44,7 @@ describe SlackStrava::Commands::Subscription, vcr: { cassette_name: 'slack/user_
 
         it 'displays subscription info' do
           current_period_end = Time.at(customer.subscriptions.first.current_period_end).strftime('%B %d, %Y')
-          bank = customer.sources.first
+          bank = Stripe::Customer.list_sources(customer.id).first
           customer_info = [
             "Customer since #{Time.at(customer.created).strftime('%B %d, %Y')}.",
             "Subscribed to Plan ($9.99), will auto-renew on #{current_period_end}.",
@@ -69,7 +69,7 @@ describe SlackStrava::Commands::Subscription, vcr: { cassette_name: 'slack/user_
         end
 
         it 'displays subscription info' do
-          card = customer.sources.first
+          card = Stripe::Customer.list_sources(customer.id).first
           current_period_end = Time.at(customer.subscriptions.first.current_period_end).strftime('%B %d, %Y')
           customer_info = [
             "Customer since #{Time.at(customer.created).strftime('%B %d, %Y')}.",
@@ -92,7 +92,7 @@ describe SlackStrava::Commands::Subscription, vcr: { cassette_name: 'slack/user_
             customer_info = "Customer since #{Time.at(customer.created).strftime('%B %d, %Y')}."
             subscription = customer.subscriptions.first
             customer_info += "\nPast Due subscription created #{Time.at(subscription.created).strftime('%B %d, %Y')} to Plan ($9.99)."
-            card = customer.sources.first
+            card = Stripe::Customer.list_sources(customer.id).first
             customer_info += "\nOn file Visa card, #{card.name} ending with #{card.last4}, expires #{card.exp_month}/#{card.exp_year}."
             customer_info += "\n#{team.update_cc_text}"
             expect(message: "#{SlackRubyBot.config.user} subscription").to respond_with_slack_message customer_info


### PR DESCRIPTION
Fixes `Team#subscription_info` raising `NoMethodError: undefined method 'sources'` on `Stripe::Customer` in stripe 13.5.1. The `sources` attribute is no longer returned on retrieved Customer objects. Use `Stripe::Customer.list_sources` instead.

Same fix as https://github.com/dblock/discord-strava/pull/101.