### PR TITLE
Fix repeated 404 errors when rebragging a deleted Strava activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Changelog
 
+* 2026/05/03: Fixed repeated 404 errors from Strava when trying to rebrag an activity that was deleted and already unbragged - added `unbragged_at` field set by `unbrag!`, excluded from `latest_bragged_activity` - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/05/02: Fixed `Team#subscription_info` failing with `NoMethodError: undefined method 'sources'` on `Stripe::Customer` in stripe 13.5.1 by using `Stripe::Customer.list_sources` - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/20: Raise a descriptive error when Slack OAuth returns `ok: false`, or when an Enterprise Grid install is attempted - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/20: Extended `stats` command to accept date expressions: year (e.g. `stats 2024`), period aliases (`weekly`, `monthly`, `quarterly`, `yearly`), and natural language ranges (e.g. `stats since January`, `stats last week`) - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### Changelog
 
-* 2026/05/03: Fixed repeated 404 errors from Strava when trying to rebrag an activity that was deleted and already unbragged - added `unbragged_at` field set by `unbrag!`, excluded from `latest_bragged_activity` - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
+* 2026/05/03: Fixed repeated 404 errors from Strava when trying to rebrag an activity that was deleted and already unbragged - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/05/02: Fixed `Team#subscription_info` failing with `NoMethodError: undefined method 'sources'` on `Stripe::Customer` in stripe 13.5.1 by using `Stripe::Customer.list_sources` - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/20: Raise a descriptive error when Slack OAuth returns `ok: false`, or when an Enterprise Grid install is attempted - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/20: Extended `stats` command to accept date expressions: year (e.g. `stats 2024`), period aliases (`weekly`, `monthly`, `quarterly`, `yearly`), and natural language ranges (e.g. `stats since January`, `stats last week`) - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).

--- a/slack-strava/models/activity.rb
+++ b/slack-strava/models/activity.rb
@@ -16,6 +16,7 @@ class Activity
   field :pr_count, type: Integer
   field :calories, type: Float
   field :bragged_at, type: DateTime
+  field :unbragged_at, type: DateTime
   field :total_elevation_gain, type: Float
   field :private, type: Boolean
   field :visibility, type: String

--- a/slack-strava/models/activity.rb
+++ b/slack-strava/models/activity.rb
@@ -35,7 +35,7 @@ class Activity
   index({ team_id: 1, 'channel_messages.channel' => 1 })
   index({ team_id: 1, bragged_at: 1, 'channel_messages.channel' => 1 })
 
-  scope :unbragged, -> { where(bragged_at: nil) }
+  scope :not_bragged, -> { where(bragged_at: nil) }
   scope :bragged, -> { where(:bragged_at.ne => nil) }
 
   belongs_to :team, inverse_of: :activities

--- a/slack-strava/models/club.rb
+++ b/slack-strava/models/club.rb
@@ -41,7 +41,7 @@ class Club
   end
 
   def brag!
-    activity = activities.unbragged.where(first_sync: false).asc(:_id).first
+    activity = activities.not_bragged.where(first_sync: false).asc(:_id).first
     return unless activity
 
     results = activity.brag!

--- a/slack-strava/models/user.rb
+++ b/slack-strava/models/user.rb
@@ -387,7 +387,7 @@ class User
   end
 
   def latest_bragged_activity(dt = 12.hours)
-    activities.bragged.where(:start_date.gt => Time.now - dt).desc(:start_date).first
+    activities.bragged.where(unbragged_at: nil, :start_date.gt => Time.now - dt).desc(:start_date).first
   end
 
   def latest_activity_start_date

--- a/slack-strava/models/user.rb
+++ b/slack-strava/models/user.rb
@@ -257,7 +257,7 @@ class User
   end
 
   def brag_new_activities!
-    activity = activities.unbragged.asc(:start_date).first
+    activity = activities.not_bragged.asc(:start_date).first
     return unless activity
 
     if team.max_activities_per_user_per_day

--- a/slack-strava/models/user_activity.rb
+++ b/slack-strava/models/user_activity.rb
@@ -115,7 +115,7 @@ class UserActivity < Activity
 
     logger.info "Unbragging about #{user}, #{self}."
     user.delete!(channel_messages)
-    update_attributes!(channel_messages: [])
+    update_attributes!(channel_messages: [], unbragged_at: Time.now.utc)
     nil
   end
 

--- a/slack-strava/models/user_activity.rb
+++ b/slack-strava/models/user_activity.rb
@@ -87,7 +87,7 @@ class UserActivity < Activity
            else
              []
            end
-      update_attributes!(bragged_at: Time.now.utc, channel_messages: rc)
+      update_attributes!(bragged_at: Time.now.utc, unbragged_at: nil, channel_messages: rc)
       rc
     end
   rescue Slack::Web::Api::Errors::SlackError => e
@@ -106,7 +106,7 @@ class UserActivity < Activity
 
     logger.info "Rebragging about #{user}, #{self}."
     rc = channel_messages.map { |channel_message| rebrag_to_channel!(channel_message) }.compact
-    update_attributes!(channel_messages: rc)
+    update_attributes!(channel_messages: rc, unbragged_at: nil)
     rc
   end
 

--- a/spec/models/club_activity_spec.rb
+++ b/spec/models/club_activity_spec.rb
@@ -208,7 +208,7 @@ describe ClubActivity do
         expect(club.team.slack_client).not_to receive(:chat_postMessage)
         expect {
           expect(activity.brag!).to be_nil
-        }.to change(club.activities.unbragged, :count).by(-1)
+        }.to change(club.activities.not_bragged, :count).by(-1)
         expect(activity.bragged_at).not_to be_nil
       end
     end
@@ -246,7 +246,7 @@ describe ClubActivity do
           expect(club.team.slack_client).not_to receive(:chat_postMessage)
           expect {
             expect(activity.brag!).to be_nil
-          }.to change(club.activities.unbragged, :count).by(-1)
+          }.to change(club.activities.not_bragged, :count).by(-1)
           expect(activity.bragged_at).not_to be_nil
         end
       end

--- a/spec/models/user_activity_spec.rb
+++ b/spec/models/user_activity_spec.rb
@@ -604,6 +604,13 @@ describe UserActivity do
         ).and_return('ts' => 'new_ts')
         activity.rebrag!
       end
+
+      it 'clears unbragged_at' do
+        activity.update_attributes!(unbragged_at: Time.now.utc)
+        allow(user.team.slack_client).to receive(:chat_update).and_return('ts' => 'new_ts')
+        activity.rebrag!
+        expect(activity.reload.unbragged_at).to be_nil
+      end
     end
 
     context 'originally bragged without activity threads, now switched to activity threads' do

--- a/spec/models/user_activity_spec.rb
+++ b/spec/models/user_activity_spec.rb
@@ -529,6 +529,7 @@ describe UserActivity do
       )
       activity.unbrag!
       expect(activity.reload.channel_messages).to eq []
+      expect(activity.reload.unbragged_at).not_to be_nil
     end
 
     context 'with activity threads' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -319,6 +319,21 @@ describe User do
           user.sync_new_strava_activities!
         end
 
+        context 'with an unbragged activity (deleted from Strava)' do
+          before do
+            user.activities.bragged.each { |a| a.update_attributes!(unbragged_at: Time.now.utc) }
+          end
+
+          it 'does not include unbragged activities in latest_bragged_activity' do
+            expect(user.send(:latest_bragged_activity)).to be_nil
+          end
+
+          it 'does not rebrag the unbragged activity' do
+            expect(user).not_to receive(:rebrag_activity!)
+            user.rebrag!
+          end
+        end
+
         context 'latest activity' do
           let(:last_activity) { user.activities.bragged.desc(:_id).first }
 


### PR DESCRIPTION
## Problem

After a Strava activity is deleted, the webhook fires `unbrag!` which sets `channel_messages: []` but leaves `bragged_at` intact. The `bragged` scope only checks `bragged_at != nil`, so `latest_bragged_activity` kept returning the deleted activity every rebrag cycle, causing repeated 404 "Record Not Found" errors from the Strava API — logged as warnings and reported to NewRelic on every pass.

## Fix

- Added `unbragged_at` DateTime field to `Activity`, set by `unbrag!`
- `latest_bragged_activity` now excludes activities where `unbragged_at` is present
- `rebrag!` and `brag!` clear `unbragged_at` so a re-added or re-published activity is tracked correctly
- Renamed `scope :unbragged` to `scope :not_bragged` to avoid confusion with the new `unbragged_at` field

## Tests

- `unbrag!` sets `unbragged_at`
- `rebrag!` clears `unbragged_at`
- `latest_bragged_activity` returns `nil` when all bragged activities have been unbragged
- `rebrag!` (on User) does not call `rebrag_activity!` for unbragged activities