### PR TITLE
Throttle past due subscription notifications to once every 72 hours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Changelog
 
+* 2026/05/03: Throttle past due subscription notifications to at most once every 72 hours - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/05/03: Fixed repeated 404 errors from Strava when trying to rebrag an activity that was deleted and already unbragged - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/05/02: Fixed `Team#subscription_info` failing with `NoMethodError: undefined method 'sources'` on `Stripe::Customer` in stripe 13.5.1 by using `Stripe::Customer.list_sources` - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/20: Raise a descriptive error when Slack OAuth returns `ok: false`, or when an Enterprise Grid install is attempted - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).

--- a/slack-strava/app.rb
+++ b/slack-strava/app.rb
@@ -213,12 +213,15 @@ module SlackStrava
                 logger.warn "Subscription for #{team} is active, but expires in under two weeks on #{subscription.current_period_end}."
               end
             when 'past_due'
+              next if team.past_due_informed_at && Time.now.utc < team.past_due_informed_at + 72.hours
+
               logger.warn "Subscription for #{team} is #{subscription.status}, notifying."
               team.inform_everyone!(text: "Your subscription to #{subscription_name} is past due. #{team.update_cc_text}")
+              team.update_attributes!(past_due_informed_at: Time.now.utc)
             when 'canceled', 'unpaid'
               logger.warn "Subscription for #{team} is #{subscription.status}, downgrading."
               team.inform_everyone!(text: "Your subscription to #{subscription.plan.nickname} (#{ActiveSupport::NumberHelper.number_to_currency(subscription.plan.amount.to_f / 100)}) was canceled and your team has been downgraded. Thank you for being a customer!")
-              team.update_attributes!(subscribed: false)
+              team.update_attributes!(subscribed: false, past_due_informed_at: nil)
             end
           end
         end

--- a/slack-strava/models/team.rb
+++ b/slack-strava/models/team.rb
@@ -37,6 +37,7 @@ class Team
   field :subscription_expired_at, type: DateTime
 
   field :trial_informed_at, type: DateTime
+  field :past_due_informed_at, type: DateTime
 
   scope :api, -> { where(api: true) }
   scope :striped, -> { where(subscribed: true, :stripe_customer_id.ne => nil) }

--- a/spec/slack-strava/app_spec.rb
+++ b/spec/slack-strava/app_spec.rb
@@ -60,16 +60,39 @@ describe SlackStrava::App do
         expect_any_instance_of(Team).to receive(:inform!).with(text: "Your subscription to Plan ($9.99) is past due. #{team.update_cc_text}")
         expect_any_instance_of(Team).to receive(:inform_admin!).with(text: "Your subscription to Plan ($9.99) is past due. #{team.update_cc_text}")
         subject.send(:check_subscribed_teams!)
+        expect(team.reload.past_due_informed_at).not_to be_nil
+      end
+
+      it 'does not re-notify past due subscription within 72 hours' do
+        team.update_attributes!(past_due_informed_at: 1.hour.ago)
+        subscription = customer.subscriptions.data.first
+        subscription['status'] = 'past_due'
+        allow(Stripe::Subscription).to receive(:list).and_return([subscription])
+        expect_any_instance_of(Team).not_to receive(:inform!)
+        expect_any_instance_of(Team).not_to receive(:inform_admin!)
+        subject.send(:check_subscribed_teams!)
+      end
+
+      it 'notifies past due subscription again after 72 hours' do
+        team.update_attributes!(past_due_informed_at: 73.hours.ago)
+        subscription = customer.subscriptions.data.first
+        subscription['status'] = 'past_due'
+        allow(Stripe::Subscription).to receive(:list).and_return([subscription])
+        expect_any_instance_of(Team).to receive(:inform!).with(text: "Your subscription to Plan ($9.99) is past due. #{team.update_cc_text}")
+        expect_any_instance_of(Team).to receive(:inform_admin!).with(text: "Your subscription to Plan ($9.99) is past due. #{team.update_cc_text}")
+        subject.send(:check_subscribed_teams!)
       end
 
       it 'notifies canceled subscription' do
         subscription = customer.subscriptions.data.first
         subscription['status'] = 'canceled'
         allow(Stripe::Subscription).to receive(:list).and_return([subscription])
+        team.update_attributes!(past_due_informed_at: 1.hour.ago)
         expect_any_instance_of(Team).to receive(:inform!).with(text: 'Your subscription to Plan ($9.99) was canceled and your team has been downgraded. Thank you for being a customer!')
         expect_any_instance_of(Team).to receive(:inform_admin!).with(text: 'Your subscription to Plan ($9.99) was canceled and your team has been downgraded. Thank you for being a customer!')
         subject.send(:check_subscribed_teams!)
         expect(team.reload.subscribed?).to be false
+        expect(team.reload.past_due_informed_at).to be_nil
       end
 
       it 'skips inactive teams' do


### PR DESCRIPTION
Adds a `past_due_informed_at` field to `Team`. When a subscription is `past_due`, the notification is only sent if no notification has been sent in the past 72 hours. The field is cleared when the subscription is canceled/downgraded.
