### PR TITLE
Consolidate ruby version to a single .ruby-version file

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,5 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "4.0.5"
           bundler-cache: true
       - run: bundle exec rubocop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,6 @@ jobs:
           mongodb-version: "8.0"
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "4.0.5"
           bundler-cache: true
       - uses: GabrielBB/xvfb-action@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Changelog
 
+* 2026/08/21: Moved ruby version to a single `.ruby-version` file read by Gemfile and auto-detected by `ruby/setup-ruby` in CI workflows, and added a Renovate `ruby-version` datasource rule so future ruby bumps update everything in one PR - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/06/27: Upgraded ruby to 4.0.5, nokogiri to 1.19.4 (security), faraday to 2.14.3, concurrent-ruby to 1.3.7, rubocop-capybara to 3.0.0 - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/06/04: Disabled club activity syncing (Strava Club Activities API removed September 1, 2026), removed dead sync code, notify club channels once that syncing has stopped - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/06/04: Strava is removing the Club Activities API on September 1, 2026. Blocked new club connections, show a deprecation notice in all club-related commands, and notify existing club channels once on next sync - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'http://rubygems.org'
 
-ruby '4.0.5'
+ruby file: '.ruby-version'
 
 gem 'base64'
 gem 'bigdecimal'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -439,7 +439,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-  ruby 4.0.5
+  ruby 4.0.6
 
 BUNDLED WITH
   4.0.10

--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,10 @@
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["patch", "minor", "major"],
       "groupName": "github actions"
+    },
+    {
+      "matchDatasources": ["ruby-version"],
+      "groupName": "ruby version"
     }
   ]
 }


### PR DESCRIPTION
The repo already had a .ruby-version file that Renovate bumps (via its built-in ruby-version datasource), but Gemfile and both CI workflows each hardcoded their own separate ruby version string. This caused drift where Renovate bumped one but not the other (e.g. #277), breaking the build with `Your Ruby version is X, but your Gemfile specified Y`.

This PR makes .ruby-version the single source of truth:
- Gemfile now reads its ruby version from .ruby-version.
- CI workflows drop the hardcoded ruby-version input; ruby/setup-ruby auto-detects .ruby-version when it isn't specified.
- renovate.json groups updates to the ruby-version datasource (the only place a ruby bump now needs to touch).