### PR TITLE
Improve homepage conversion

### DIFF
--- a/public/index.html.erb
+++ b/public/index.html.erb
@@ -32,29 +32,38 @@
     <h1>Slava: Strava integration with Slack</h1>
   </p>
   <p>
-    Connects Strava in Slack and reposts athlete activities into Slack channels, including time, distance, pace, map and weather.
-    <br>
-    Improves unfurling of Strava links for connected athletes.
+    Connects Strava in Slack and reposts athlete activities into Slack channels.
+  </p>
+  <p>
+    ⏱ Moving and elapsed time, distance, pace, map and weather
+    <br>🔗 Improves unfurling of Strava links for connected athletes
+    <br>💬 Perfect for your Slack running or cycling club
+  </p>
+  <p id='messages' />
+  <p class='register'>
+    <a href="https://slack.com/oauth/authorize?scope=<%= ENV['SLACK_OAUTH_SCOPE'] %>&client_id=<%= ENV['SLACK_CLIENT_ID'] %>"><img alt="Add Slava to Slack" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcset="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x"></a>
   </p>
   <p>
     <small>
-      Looking to add Strava to Discord? Check out <a href="https://strada.playplay.io" target="_blank">Strada</a>.
+      Free 2 week trial, no credit card required. Subscribe for $9.99/yr.
     </small>
-  </p>
-  <p>&nbsp;</p>
-  <p id='messages' />
-  <p id='register'>
-    <a href="https://slack.com/oauth/authorize?scope=<%= ENV['SLACK_OAUTH_SCOPE'] %>&client_id=<%= ENV['SLACK_CLIENT_ID'] %>"><img alt="Add Slava to Slack" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcset="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x"></a>
   </p>
   <p>&nbsp;</p>
   <p class='image'>
     <img src='img/notify.png' alt="Example Strava activity notification posted to a Slack channel">
   </p>
+  <p class='register'>
+    <a href="https://slack.com/oauth/authorize?scope=<%= ENV['SLACK_OAUTH_SCOPE'] %>&client_id=<%= ENV['SLACK_CLIENT_ID'] %>"><img alt="Add Slava to Slack" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcset="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x"></a>
+  </p>
+  <p>&nbsp;</p>
   <p>
     <small>
-      Free 2 week trial, no credit card required. Subscribe for $9.99/yr.
-      <br>
       All proceeds go to <a href="https://www.nyrr.org/" target="_blank">nyrr.org</a>.
+    </small>
+  </p>
+  <p>
+    <small>
+      Looking to add Strava to Discord? Check out <a href="https://strada.playplay.io" target="_blank">Strada</a>.
     </small>
   </p>
   <p class='logo'>

--- a/public/scripts/register.js
+++ b/public/scripts/register.js
@@ -3,7 +3,7 @@ $(document).ready(function() {
   var code = $.url('?code')
   if (code) {
     SlackStrava.message('Working, please wait ...');
-    $('#register').hide();
+    $('.register').hide();
     $.ajax({
       type: "POST",
       url: "/api/teams",

--- a/spec/integration/homepage_spec.rb
+++ b/spec/integration/homepage_spec.rb
@@ -19,6 +19,6 @@ describe 'Homepage', :js, type: :feature do
   end
 
   it 'includes a link to add to slack with the client id' do
-    expect(find("a[href='https://slack.com/oauth/authorize?scope=scope:read&client_id=client_id']"))
+    expect(all("a[href='https://slack.com/oauth/authorize?scope=scope:read&client_id=client_id']").size).to eq(2)
   end
 end


### PR DESCRIPTION
Mirrors the conversion improvements made on discord-strava's homepage:
- Move the "Add to Slack" CTA above the fold, right after the tagline
- Replace the long descriptive paragraph with scannable feature bullets
- Repeat the CTA button after the example screenshot
- Move pricing note closer to the top CTA

No functional/behavioral change; `#register` was renamed to `.register` since there are now two instances on the page (register.js updated accordingly).