### PR TITLE
Add hover pop effect to the Add to Slack button

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -21,6 +21,16 @@ body {
   width: 100%;
 }
 
+.register img {
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  transition: transform 0.1s ease-in-out;
+}
+
+.register img:hover {
+  transform: scale(1.03);
+}
+
 .has-error {
   color: red;
 }


### PR DESCRIPTION
Matches discord-strava's install button hover effect: subtle shadow and scale-up on hover to make the CTA feel more interactive/button-like.