### PR TITLE
Reserve space for the async status message to prevent layout shift

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -31,6 +31,10 @@ body {
   transform: scale(1.03);
 }
 
+#messages {
+  min-height: 1.5em;
+}
+
 .has-error {
   color: red;
 }


### PR DESCRIPTION
The "Together, N athletes logged X miles this month!" message is fetched asynchronously and injected into `#messages`, which had no reserved height. This caused the CTA button and screenshot below it to visually jump down once the message loaded. Reserves min-height for #messages to prevent the shift, matching the same fix applied to discord-strava.